### PR TITLE
Rename `pack_flatten` to `pack_for_lodo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,20 +80,20 @@ This is mostly to cover use cases where you need access to `'domain_names'` labe
 
 Considering different scenarios, the dataset provides the following helpers:
 
-* `pack_for_train` masks labels for domains designated for being used as targets
-* `pack_for_test` packs requested targets
+* `pack_train` masks labels for domains designated for being used as targets
+* `pack_test` packs requested targets
 
 Working with an estimator with a new API would look like the following:
 
 ```python
 office31 = fetch_office31_surf_all()
-X_train, y_train, sample_domain = office31.pack_for_train(as_sources=['amazon', 'dslr'], as_targets=['webcam'])
+X_train, y_train, sample_domain = office31.pack_train(as_sources=['amazon', 'dslr'], as_targets=['webcam'])
 
 estimator = make_da_pipeline(TCLAdapter(n_components=5, random_state=0),LogisticRegression())
 estimator.fit(X_train, y_train, sample_domain=sample_domain)
 
 # predict and score on target domain
-X_test, y_test, sample_domain = office31.pack_for_test(as_targets=['webcam'])
+X_test, y_test, sample_domain = office31.pack_test(as_targets=['webcam'])
 webcam_idx = office31.select_domain(sample_domain, 'webcam')
 y_target = estimator.predict(X_test,[webcam_idx], sample_domain=sample_domain[webcam_idx])
 score = estimator.score(X_test[webcam_idx], y=y_test[webcam_idx], sample_domain=sample_domain[webcam_idx])
@@ -195,7 +195,7 @@ See API usage examples in `skada/tests/test_scorer.py`.
 The `SupervisedScorer` is a unique scorer that necessitates special consideration. Since it requires access to target labels, which are masked during the dataset packing process for training, this scorer mandates an additional key to be passed within the `params`. The usage is as follows:
 
 ```python
-X, y, sample_domain = da_dataset.pack_for_train(as_sources=['s'], as_targets=['t'])
+X, y, sample_domain = da_dataset.pack_train(as_sources=['s'], as_targets=['t'])
 estimator = make_da_pipeline(
     ReweightDensityAdapter(),
     LogisticRegression().set_score_request(sample_weight=True),
@@ -222,7 +222,7 @@ The library includes a range of splitters designed specifically for domain adapt
 `skada.model_selection.SourceTargetShuffleSplit`: This splitter functions similarly to the standard `ShuffleSplit` but takes into account the distinct separation between source and target domains. It follows the standard API structure:
 
 ```python
-X, y, sample_domain = da_dataset.pack_for_train(as_sources=['s', 's2'], as_targets=['t', 't2'])
+X, y, sample_domain = da_dataset.pack_train(as_sources=['s', 's2'], as_targets=['t', 't2'])
 pipe = make_da_pipeline(
     SubspaceAlignmentAdapter(n_components=2),
     LogisticRegression(),
@@ -242,10 +242,10 @@ scores = cross_validate(
 
 `skada.model_selection.LeaveOneDomainOut` is a cross-validator that, in each iteration, randomly selects a single domain to serve as the target. After this selection, the train/test split is performed using the `ShuffleSplit` algorithm. The `max_n_splits` parameter limits the number of splits; in its absence, each domain is used as a target exactly once.
 
-This splitter requires the dataset to be specially prepared so that each domain is represented as both a source and a target simultaneously. This preparation can be achieved using the `pack_for_lodo` method. An example is provided below for clarity:
+This splitter requires the dataset to be specially prepared so that each domain is represented as both a source and a target simultaneously. This preparation can be achieved using the `pack_lodo` method. An example is provided below for clarity:
 
 ```python
-X, y, sample_domain = da_dataset.pack_for_lodo()
+X, y, sample_domain = da_dataset.pack_lodo()
 pipe = make_da_pipeline(
     SubspaceAlignmentAdapter(n_components=2),
     LogisticRegression(),

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-> **Warning**
-This library is currently in a phase of active development. All features are subject to change without prior notice.
-If you are interested in collaborating, please feel free to reach out by opening an issue or starting a discussion.
-
+> [!WARNING]
+> This library is currently in a phase of active development. All features are subject to change without prior notice. If you are interested in collaborating, please feel free to reach out by opening an issue or starting a discussion.
 
 # Domain Aware API
 

--- a/README.md
+++ b/README.md
@@ -242,10 +242,10 @@ scores = cross_validate(
 
 `skada.model_selection.LeaveOneDomainOut` is a cross-validator that, in each iteration, randomly selects a single domain to serve as the target. After this selection, the train/test split is performed using the `ShuffleSplit` algorithm. The `max_n_splits` parameter limits the number of splits; in its absence, each domain is used as a target exactly once.
 
-This splitter requires the dataset to be specially prepared so that each domain is represented as both a source and a target simultaneously. This preparation can be achieved using the `pack_flatten` method. An example is provided below for clarity:
+This splitter requires the dataset to be specially prepared so that each domain is represented as both a source and a target simultaneously. This preparation can be achieved using the `pack_for_lodo` method. An example is provided below for clarity:
 
 ```python
-X, y, sample_domain = da_dataset.pack_flatten()
+X, y, sample_domain = da_dataset.pack_for_lodo()
 pipe = make_da_pipeline(
     SubspaceAlignmentAdapter(n_components=2),
     LogisticRegression(),

--- a/examples/methods/plot_optimal_transport_da.py
+++ b/examples/methods/plot_optimal_transport_da.py
@@ -95,7 +95,7 @@ dataset = DomainAwareDataset(domains=[
     (X_source, y_source, 's'),
     (X_target, y_target, 't')
 ])
-X_train, y_train, sample_domain = dataset.pack_for_train(
+X_train, y_train, sample_domain = dataset.pack_train(
     as_sources=['s'],
     as_targets=['t']
 )
@@ -215,7 +215,7 @@ clf_otda_sinkhorn = DomainAwareEstimator(
     SVC(kernel='rbf', C=1)
 )
 clf_otda_sinkhorn.fit(X_train, y_train, sample_domain)
-X_test, y_test, sample_domain_test = dataset.pack_for_test(as_targets=['t'])
+X_test, y_test, sample_domain_test = dataset.pack_test(as_targets=['t'])
 ACC_sinkhorn = clf_otda_sinkhorn.score(X_test, y_test, sample_domain_test)
 X_adapted_sinkhorn = clf_otda_sinkhorn.adapt(X_train, y_train, sample_domain)[0]
 X_source_adapted_sinkhorn = X_adapted_sinkhorn[sample_domain > 0]

--- a/examples/validation/plot_cross_val_score_for_da.py
+++ b/examples/validation/plot_cross_val_score_for_da.py
@@ -38,7 +38,7 @@ estimator = EntropicOTMapping(
     tol=1e-3
 )
 
-X, y, sample_domain = dataset.pack_for_train(as_sources=['s'], as_targets=['t'])
+X, y, sample_domain = dataset.pack_train(as_sources=['s'], as_targets=['t'])
 X_source, y_source, X_target, y_target = source_target_split(X, y, sample_domain)
 cv = ShuffleSplit(n_splits=5, test_size=0.3, random_state=0)
 

--- a/examples/validation/plot_gridsearch_for_da.py
+++ b/examples/validation/plot_gridsearch_for_da.py
@@ -31,8 +31,8 @@ dataset = make_shifted_datasets(
     random_state=42,
     return_dataset=True
 )
-X, y, sample_domain = dataset.pack_for_train(as_sources=['s'], as_targets=['t'])
-X_target, y_target, _ = dataset.pack_for_test(as_targets=['t'])
+X, y, sample_domain = dataset.pack_train(as_sources=['s'], as_targets=['t'])
+X_target, y_target, _ = dataset.pack_test(as_targets=['t'])
 
 # %%
 # Run grid search

--- a/skada/datasets/_base.py
+++ b/skada/datasets/_base.py
@@ -25,6 +25,11 @@ DomainDataType = Union[
     Tuple[np.ndarray,],
 ]
 
+PackedDatasetType = Union[
+    Bunch,
+    Tuple[np.ndarray, np.ndarray, np.ndarray]
+]
+
 
 def get_data_home(data_home: Union[str, os.PathLike, None]) -> str:
     """Return the path of the `skada` data folder.
@@ -130,9 +135,10 @@ class DomainAwareDataset:
         return_X_y: bool = True,
         train: bool = False,
         mask: Union[None, int, float] = None,
-    ) -> Union[Bunch, Tuple[np.ndarray, np.ndarray, np.ndarray]]:
-        """Takes all domain datasets and packs them into a single
-        domain-aware representation compatible with DA estimators.
+    ) -> PackedDatasetType:
+        """Aggregates datasets from all domains into a unified domain-aware
+        representation, ensuring compatibility with domain adaptation (DA)
+        estimators.
 
         Parameters
         ----------
@@ -159,7 +165,7 @@ class DomainAwareDataset:
                 Samples from all sources and all targets given.
             target : ndarray
                 Target labels from all sources and all targets.
-            sample_domain : ndarray)
+            sample_domain : ndarray
                 The integer label for domain the sample was taken from.
                 By convention, source domains have non-negative labels,
                 and target domain label is always < 0.
@@ -235,8 +241,8 @@ class DomainAwareDataset:
         as_targets: List[str],
         return_X_y: bool = True,
         mask: Union[None, int, float] = None,
-    ):
-        """Same as pack.
+    ) -> PackedDatasetType:
+        """Same as `pack`.
 
         Masks labels for target domains with -1 so they are not available
         at training time.
@@ -253,7 +259,7 @@ class DomainAwareDataset:
         self,
         as_targets: List[str],
         return_X_y: bool = True,
-    ):
+    ) -> PackedDatasetType:
         return self.pack(
             as_sources=[],
             as_targets=as_targets,
@@ -261,7 +267,41 @@ class DomainAwareDataset:
             train=False,
         )
 
-    def pack_flatten(self, return_X_y: bool = True):
+    def pack_for_lodo(self, return_X_y: bool = True) -> PackedDatasetType:
+        """Packages all domains in a format compatible with the Leave-One-Domain-Out
+        cross-validator (refer to :class:`~skada.model_selection.LeaveOneDomainOut` for
+        more details). To enable the splitter's dynamic assignment of source and target
+        domains, data from each domain is included in the output twice.
+
+        Exercise caution when using this output for purposes other than its intended
+        use, as this could lead to incorrect results.
+
+        Parameters
+        ----------
+        return_X_y : bool, default=True
+            When set to True, returns a tuple (X, y, sample_domain). Otherwise
+            returns :class:`~sklearn.utils.Bunch` object with the structure
+            described below.
+
+        Returns
+        -------
+        data : :class:`~sklearn.utils.Bunch`
+            Dictionary-like object, with the following attributes.
+
+            data: np.ndarray
+                Samples from all sources and all targets given.
+            target : np.ndarray
+                Target labels from all sources and all targets.
+            sample_domain : np.ndarray
+                The integer label for domain the sample was taken from.
+                By convention, source domains have non-negative labels,
+                and target domain label is always < 0.
+            domain_names : dict
+                The names of domains and associated domain labels.
+
+        (X, y, sample_domain) : tuple if `return_X_y=True`
+            Tuple of (data, target, sample_domain), see the description above.
+        """
         return self.pack(
             as_sources=list(self.domain_names_.keys()),
             as_targets=list(self.domain_names_.keys()),

--- a/skada/datasets/_base.py
+++ b/skada/datasets/_base.py
@@ -235,7 +235,7 @@ class DomainAwareDataset:
             domain_names=domain_labels,
         )
 
-    def pack_for_train(
+    def pack_train(
         self,
         as_sources: List[str],
         as_targets: List[str],
@@ -255,7 +255,7 @@ class DomainAwareDataset:
             mask=mask,
         )
 
-    def pack_for_test(
+    def pack_test(
         self,
         as_targets: List[str],
         return_X_y: bool = True,
@@ -267,7 +267,7 @@ class DomainAwareDataset:
             train=False,
         )
 
-    def pack_for_lodo(self, return_X_y: bool = True) -> PackedDatasetType:
+    def pack_lodo(self, return_X_y: bool = True) -> PackedDatasetType:
         """Packages all domains in a format compatible with the Leave-One-Domain-Out
         cross-validator (refer to :class:`~skada.model_selection.LeaveOneDomainOut` for
         more details). To enable the splitter's dynamic assignment of source and target

--- a/skada/datasets/_base.py
+++ b/skada/datasets/_base.py
@@ -271,8 +271,8 @@ class DomainAwareDataset:
         """Packages all domains in a format compatible with the Leave-One-Domain-Out
         cross-validator (refer to :class:`~skada.model_selection.LeaveOneDomainOut` for
         more details). To enable the splitter's dynamic assignment of source and target
-        domains, data from each domain is included in the output twice — once as a source
-        and once as a target.
+        domains, data from each domain is included in the output twice — once as a
+        source and once as a target.
 
         Exercise caution when using this output for purposes other than its intended
         use, as this could lead to incorrect results and data leakage.

--- a/skada/datasets/_base.py
+++ b/skada/datasets/_base.py
@@ -271,10 +271,11 @@ class DomainAwareDataset:
         """Packages all domains in a format compatible with the Leave-One-Domain-Out
         cross-validator (refer to :class:`~skada.model_selection.LeaveOneDomainOut` for
         more details). To enable the splitter's dynamic assignment of source and target
-        domains, data from each domain is included in the output twice.
+        domains, data from each domain is included in the output twice — once as a source
+        and once as a target.
 
         Exercise caution when using this output for purposes other than its intended
-        use, as this could lead to incorrect results.
+        use, as this could lead to incorrect results and data leakage.
 
         Parameters
         ----------

--- a/skada/datasets/tests/test_base.py
+++ b/skada/datasets/tests/test_base.py
@@ -12,7 +12,7 @@ def test_dataset_train_label_masking():
     dataset = DomainAwareDataset()
     dataset.add_domain(np.array([1., 2.]), np.array([1, 2]), 's1')
     dataset.add_domain(np.array([10., 20., 30.]), np.array([10, 20, 30]), 't1')
-    X, y, sample_domain = dataset.pack_for_train(as_sources=['s1'], as_targets=['t1'])
+    X, y, sample_domain = dataset.pack_train(as_sources=['s1'], as_targets=['t1'])
 
     # test shape of the output
     assert X.shape == (5,)
@@ -26,12 +26,12 @@ def test_dataset_train_label_masking():
     assert np.all(y[sample_domain > 0] > 0)
 
     # custom mask
-    X, y, sample_domain = dataset.pack_for_train(
+    X, y, sample_domain = dataset.pack_train(
         as_sources=['s1'], as_targets=['t1'], mask=-10)
     assert_array_equal(y[sample_domain < 0], np.array([-10, -10, -10]))
 
     # test packing does not perform masking
-    X, y, sample_domain = dataset.pack_for_test(as_targets=['t1'])
+    X, y, sample_domain = dataset.pack_test(as_targets=['t1'])
     assert X.shape == (3,)
     assert y.shape == (3,)
     assert sample_domain.shape == (3,)

--- a/skada/tests/test_cv.py
+++ b/skada/tests/test_cv.py
@@ -86,7 +86,7 @@ def test_domain_aware_split(da_dataset):
     [(2, 2), (10, 4)]
 )
 def test_leave_one_domain_out(da_dataset, max_n_splits, n_splits):
-    X, y, sample_domain = da_dataset.pack_flatten()
+    X, y, sample_domain = da_dataset.pack_for_lodo()
     pipe = make_da_pipeline(
         SubspaceAlignmentAdapter(n_components=2),
         LogisticRegression(),

--- a/skada/tests/test_cv.py
+++ b/skada/tests/test_cv.py
@@ -33,7 +33,7 @@ def test_group_based_cv(da_dataset, cv, n_splits):
     assert hasattr(cv, 'set_split_request'), 'splitter has to support routing'
     cv.set_split_request(groups='sample_domain')
     # single source, single target, target labels are masked
-    X, y, sample_domain = da_dataset.pack_for_train(
+    X, y, sample_domain = da_dataset.pack_train(
         as_sources=['s', 's2'],
         as_targets=['t', 't2']
     )
@@ -58,7 +58,7 @@ def test_group_based_cv(da_dataset, cv, n_splits):
 
 
 def test_domain_aware_split(da_dataset):
-    X, y, sample_domain = da_dataset.pack_for_train(
+    X, y, sample_domain = da_dataset.pack_train(
         as_sources=['s', 's2'],
         as_targets=['t', 't2']
     )
@@ -86,7 +86,7 @@ def test_domain_aware_split(da_dataset):
     [(2, 2), (10, 4)]
 )
 def test_leave_one_domain_out(da_dataset, max_n_splits, n_splits):
-    X, y, sample_domain = da_dataset.pack_for_lodo()
+    X, y, sample_domain = da_dataset.pack_lodo()
     pipe = make_da_pipeline(
         SubspaceAlignmentAdapter(n_components=2),
         LogisticRegression(),

--- a/skada/tests/test_mapping.py
+++ b/skada/tests/test_mapping.py
@@ -65,12 +65,12 @@ def test_mapping_estimator(estimator, tmp_da_dataset):
         (X_target_scaled, y_target, 't'),
     ])
 
-    X_train, y_train, sample_domain = dataset.pack_for_train(
+    X_train, y_train, sample_domain = dataset.pack_train(
         as_sources=['s'],
         as_targets=['t']
     )
     estimator.fit(X_train, y_train, sample_domain=sample_domain)
-    X_test, y_test, sample_domain = dataset.pack_for_test(as_targets=['t'])
+    X_test, y_test, sample_domain = dataset.pack_test(as_targets=['t'])
     y_pred = estimator.predict(X_test, sample_domain=sample_domain)
     assert np.mean(y_pred == y_test) > 0.9
     score = estimator.score(X_test, y_test, sample_domain=sample_domain)

--- a/skada/tests/test_pipeline.py
+++ b/skada/tests/test_pipeline.py
@@ -18,7 +18,7 @@ import pytest
 
 def test_pipeline(da_dataset):
     # single source, single target, target labels are masked
-    X, y, sample_domain = da_dataset.pack_for_train(as_sources=['s'], as_targets=['t'])
+    X, y, sample_domain = da_dataset.pack_train(as_sources=['s'], as_targets=['t'])
     # by default, each estimator in the pipeline is wrapped into `Shared` selector
     pipe = make_da_pipeline(
         StandardScaler(),
@@ -34,7 +34,7 @@ def test_pipeline(da_dataset):
     with pytest.raises(ValueError):
         pipe.score(X, y, sample_domain=sample_domain)
     # target only, no label masking
-    X_target, y_target, sample_domain = da_dataset.pack_for_test(as_targets=['t'])
+    X_target, y_target, sample_domain = da_dataset.pack_test(as_targets=['t'])
     y_pred = pipe.predict(X_target, sample_domain=sample_domain)
     assert np.mean(y_pred == y_target) > 0.9
     # automatically derives as a single target domain when sample_domain is `None`

--- a/skada/tests/test_reweight.py
+++ b/skada/tests/test_reweight.py
@@ -42,12 +42,12 @@ import pytest
     ],
 )
 def test_reweight_estimator(estimator, da_dataset):
-    X_train, y_train, sample_domain = da_dataset.pack_for_train(
+    X_train, y_train, sample_domain = da_dataset.pack_train(
         as_sources=['s'],
         as_targets=['t']
     )
     estimator.fit(X_train, y_train, sample_domain=sample_domain)
-    X_test, y_test, sample_domain = da_dataset.pack_for_test(as_targets=['t'])
+    X_test, y_test, sample_domain = da_dataset.pack_test(as_targets=['t'])
     y_pred = estimator.predict(X_test, sample_domain=sample_domain)
     assert np.mean(y_pred == y_test) > 0.9
     score = estimator.score(X_test, y_test, sample_domain=sample_domain)

--- a/skada/tests/test_scorer.py
+++ b/skada/tests/test_scorer.py
@@ -34,7 +34,7 @@ import pytest
     ],
 )
 def test_generic_scorer(scorer, da_dataset):
-    X, y, sample_domain = da_dataset.pack_for_train(as_sources=['s'], as_targets=['t'])
+    X, y, sample_domain = da_dataset.pack_train(as_sources=['s'], as_targets=['t'])
     estimator = make_da_pipeline(
         ReweightDensityAdapter(),
         LogisticRegression().set_score_request(sample_weight=True),
@@ -54,7 +54,7 @@ def test_generic_scorer(scorer, da_dataset):
 
 def test_supervised_scorer(da_dataset):
     """`SupervisedScorer` requires unmasked target label to be available."""
-    X, y, sample_domain = da_dataset.pack_for_train(as_sources=['s'], as_targets=['t'])
+    X, y, sample_domain = da_dataset.pack_train(as_sources=['s'], as_targets=['t'])
     estimator = make_da_pipeline(
         ReweightDensityAdapter(),
         LogisticRegression().set_score_request(sample_weight=True),
@@ -86,7 +86,7 @@ def test_supervised_scorer(da_dataset):
     ],
 )
 def test_scorer_with_entropy_requires_predict_proba(scorer, da_dataset):
-    X, y, sample_domain = da_dataset.pack_for_train(as_sources=['s'], as_targets=['t'])
+    X, y, sample_domain = da_dataset.pack_train(as_sources=['s'], as_targets=['t'])
     estimator = make_da_pipeline(ReweightDensityAdapter(), SVC())
     estimator.fit(X, y, sample_domain=sample_domain)
     with pytest.raises(AttributeError):
@@ -100,7 +100,7 @@ def test_scorer_with_log_proba():
         (rng.rand(n_samples, n_features), rng.randint(2, size=n_samples), 's'),
         (rng.rand(n_samples, n_features), None, 't')
     ])
-    X, y, sample_domain = dataset.pack_for_train(as_sources=['s'], as_targets=['t'])
+    X, y, sample_domain = dataset.pack_train(as_sources=['s'], as_targets=['t'])
     estimator = make_da_pipeline(
         SubspaceAlignmentAdapter(n_components=2),
         LogisticRegression()

--- a/skada/tests/test_subspace.py
+++ b/skada/tests/test_subspace.py
@@ -35,12 +35,12 @@ import pytest
     ]
 )
 def test_subspace_alignment(estimator, da_dataset):
-    X_train, y_train, sample_domain = da_dataset.pack_for_train(
+    X_train, y_train, sample_domain = da_dataset.pack_train(
         as_sources=['s'],
         as_targets=['t']
     )
     estimator.fit(X_train, y_train, sample_domain=sample_domain)
-    X_test, y_test, sample_domain = da_dataset.pack_for_test(as_targets=['t'])
+    X_test, y_test, sample_domain = da_dataset.pack_test(as_targets=['t'])
     y_pred = estimator.predict(X_test, sample_domain=sample_domain)
     assert np.mean(y_pred == y_test) > 0.9
     score = estimator.score(X_test, y_test, sample_domain=sample_domain)
@@ -69,12 +69,12 @@ def test_subspace_default_n_components(adapter, n_samples, n_features, n_compone
         (X_target, y_target, 't'),
     ])
 
-    X_train, y_train, sample_domain = dataset.pack_for_train(
+    X_train, y_train, sample_domain = dataset.pack_train(
         as_sources=['s'],
         as_targets=['t']
     )
     adapter.fit(X_train, y_train, sample_domain=sample_domain)
-    X_test, _, sample_domain = dataset.pack_for_test(as_targets=['t'])
+    X_test, _, sample_domain = dataset.pack_test(as_targets=['t'])
     output = adapter.transform(X_test, sample_domain=sample_domain)
     if isinstance(output, AdaptationOutput):
         output = output['X']


### PR DESCRIPTION
Change the name of the method to be precise that the out is only useful when doing Leave-One-Domain-Out.

Additional docstrings are provided as well.

Closes #5.