### PR TITLE
Pipeline to respect `default_selector` parameters

### DIFF
--- a/skada/_pipeline.py
+++ b/skada/_pipeline.py
@@ -53,10 +53,10 @@ def make_da_pipeline(
 
     default_selector : str or callable, default = 'shared'
         Specifies a domain selector to wrap the estimator, if it is not already
-        wrapped. Refer to :class:~skada.base.BaseSelector for an understanding of
+        wrapped. Refer to :class:`~skada.base.BaseSelector` for an understanding of
         selector functionalities. The available options include 'shared' and
-        'per-domain'. For integrating a custom selector as the default, pass a
-        callable that accepts :class:~sklearn.base.BaseEstimator and returns
+        'per_domain'. For integrating a custom selector as the default, pass a
+        callable that accepts :class:`~sklearn.base.BaseEstimator` and returns
         the estimator encapsulated within a domain selector.
 
     Returns
@@ -86,6 +86,9 @@ def _wrap_with_selector(
     if not isinstance(estimator, BaseSelector):
         if callable(selector):
             estimator = selector(estimator)
+            if not isinstance(estimator, BaseSelector):
+                raise ValueError("Callable `default_selector` has to return `BaseSelector` "  # noqa: E501
+                                 f"instance, got {type(estimator)} instead.")
         elif isinstance(selector, str):
             selector_cls = _DEFAULT_SELECTORS.get(selector)
             if selector_cls is None:

--- a/skada/tests/test_pipeline.py
+++ b/skada/tests/test_pipeline.py
@@ -75,6 +75,10 @@ def test_per_domain_selector():
             marks=pytest.mark.xfail(reason='Fails non-existing selector')
         ),
         pytest.param(
+            42, None,
+            marks=pytest.mark.xfail(reason='Fails uninterpretable type')
+        ),
+        pytest.param(
             lambda x: 42, None,
             marks=pytest.mark.xfail(reason='Incorrect output type for the callable')
         )

--- a/skada/tests/test_pipeline.py
+++ b/skada/tests/test_pipeline.py
@@ -73,6 +73,10 @@ def test_per_domain_selector():
         pytest.param(
             'non_existing_one', None,
             marks=pytest.mark.xfail(reason='Fails non-existing selector')
+        ),
+        pytest.param(
+            lambda x: 42, None,
+            marks=pytest.mark.xfail(reason='Incorrect output type for the callable')
         )
     ]
 )

--- a/skada/tests/test_pipeline.py
+++ b/skada/tests/test_pipeline.py
@@ -84,3 +84,15 @@ def test_default_selector_parameter(selector_name, selector_cls):
     )
     _, estimator = pipe.steps[0]
     assert isinstance(estimator, selector_cls)
+
+
+def test_default_selector_ignored_for_selector():
+    pipe = make_da_pipeline(
+        Shared(SubspaceAlignmentAdapter(n_components=2)),
+        LogisticRegression(),
+        default_selector='per_domain',
+    )
+    _, estimator = pipe.steps[0]
+    assert isinstance(estimator, Shared)
+    _, estimator = pipe.steps[1]
+    assert isinstance(estimator, PerDomain)


### PR DESCRIPTION
Closes #13.

Provides rather rigid handling for what might and might not be a default selectors. Tests are implemented for all edge cases.