### PR TITLE
Switch from dev0 to stable sklearn 1.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
             command: |
               python -m pip install --user --upgrade --progress-bar off pip
               python -m pip install --user --progress-bar off -r requirements.txt
-              python -m pip install --user --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple 'scikit-learn==1.4.dev0'
               python -m pip install --user --upgrade --progress-bar off -r docs/requirements.txt     
               python -m pip install --user --upgrade --progress-bar off .
           # python -m pip install --user --upgrade --progress-bar off ipython "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master" memory_profiler

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,7 +42,6 @@ jobs:
       run: |
         python -m pip install --user --upgrade --progress-bar off pip
         python -m pip install --user -r requirements.txt
-        python -m pip install --user --pre --upgrade 'scikit-learn==1.4.0rc1'
         python -m pip install --user --upgrade pytest pytest-cov codecov 
     - name: Install 'skada' package
       run: |
@@ -85,7 +84,6 @@ jobs:
       run: |
         python -m pip install --user --upgrade --progress-bar off pip
         python -m pip install --user -r requirements_full.txt
-        python -m pip install --user --pre --upgrade 'scikit-learn==1.4.0rc1'
         python -m pip install --user --upgrade pytest pytest-cov codecov 
     - name: Install 'skada' package
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.24
 scipy>=1.10
+scikit-learn>=1.4.0
 pot>=0.9.0


### PR DESCRIPTION
Right now building of docs fails because old dev0 version is missing.