### PR TITLE
Fix masked inputs filtering in the base selector for regression tasks

### DIFF
--- a/skada/base.py
+++ b/skada/base.py
@@ -239,7 +239,7 @@ class BaseSelector(BaseEstimator):
         if y_type == 'classification':
             unmasked_idx = (y != _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL)
         elif y_type == 'continuous':
-            unmasked_idx = ~np.isfinite(y)
+            unmasked_idx = np.isfinite(y)
 
         X = X[unmasked_idx]
         y = y[unmasked_idx]

--- a/skada/tests/test_selector.py
+++ b/skada/tests/test_selector.py
@@ -108,8 +108,11 @@ def test_base_selector_remove_masked_continuous():
     source_idx = rng.choice([False, True], size=n_samples)
     # mask target labels
     y[~source_idx] = _DEFAULT_MASKED_TARGET_REGRESSION_LABEL
-    X_output, y_output, _ = selector._remove_masked(X, y, {})
+    assert np.any(~np.isfinite(y)), 'at least one label is masked'
 
-    n_target_samples = X.shape[0] - np.sum(source_idx)
-    assert X_output.shape[0] == n_target_samples, "X output shape mismatch"
+    X_output, y_output, _ = selector._remove_masked(X, y, {})
+    assert np.all(np.isfinite(y_output)), 'masks are removed'
+
+    n_source_samples = np.sum(source_idx)
+    assert X_output.shape[0] == n_source_samples, 'X output shape mismatch'
     assert X_output.shape[0] == y_output.shape[0]


### PR DESCRIPTION
Closes #83.

```python
import numpy as np
from sklearn.linear_model import LinearRegression
from skada import KLIEP

X_source = np.ones(10)
X_target = X_source

y_source = np.ones(10)
y_target = np.zeros(10)

from skada.datasets import DomainAwareDataset
dataset = DomainAwareDataset([(X_source, y_source, 's'), (X_target, y_target, 't')])
X, y, sample_domain = dataset.pack_train(as_sources=['s'], as_targets=['t'])

lr = LinearRegression()

kliep = KLIEP(base_estimator=lr)

kliep.fit(X.reshape(-1, 1), y, sample_domain=sample_domain)
kliep.predict(X.reshape(-1, 1))
Out[7]:
array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1.])
```