### PR TITLE
Properly process `sample_weight` when using reweight adapters

### DIFF
--- a/examples/plot_method_comparison.py
+++ b/examples/plot_method_comparison.py
@@ -61,12 +61,12 @@ names = [
 classifiers = [
     SVC(),
     ReweightDensity(
-        base_estimator=SVC(),
+        base_estimator=SVC().set_fit_request(sample_weight=True),
         weight_estimator=KernelDensity(bandwidth=0.5),
     ),
-    GaussianReweightDensity(base_estimator=SVC()),
-    DiscriminatorReweightDensity(base_estimator=SVC()),
-    KLIEP(base_estimator=SVC(), gamma=[1, 0.1, 0.001]),
+    GaussianReweightDensity(SVC().set_fit_request(sample_weight=True)),
+    DiscriminatorReweightDensity(SVC().set_fit_request(sample_weight=True)),
+    KLIEP(SVC().set_fit_request(sample_weight=True), gamma=[1, 0.1, 0.001]),
     SubspaceAlignment(base_estimator=SVC(), n_components=1),
     TransferComponentAnalysis(base_estimator=SVC(), n_components=1, mu=0.5),
     OTMapping(base_estimator=SVC()),

--- a/skada/_reweight.py
+++ b/skada/_reweight.py
@@ -65,10 +65,12 @@ class ReweightDensityAdapter(BaseAdapter):
         X, sample_domain = check_X_domain(X, sample_domain)
         X_source, X_target = source_target_split(X, sample_domain=sample_domain)
 
-        self.weight_estimator_source_ = clone(self.weight_estimator)
-        self.weight_estimator_target_ = clone(self.weight_estimator)
-        self.weight_estimator_source_.fit(X_source)
-        self.weight_estimator_target_.fit(X_target)
+        source_estimator = clone(self.weight_estimator)
+        source_estimator.fit(X_source)
+        target_estimator = clone(self.weight_estimator)
+        target_estimator.fit(X_target)
+        self.weight_estimator_source_ = source_estimator
+        self.weight_estimator_target_ = target_estimator
         return self
 
     def adapt(self, X, y=None, sample_domain=None):
@@ -85,12 +87,13 @@ class ReweightDensityAdapter(BaseAdapter):
 
         Returns
         -------
-        X_t : array-like, shape (n_samples, n_components)
-            The data (same as X).
-        y_t : array-like, shape (n_samples,)
-            The labels (same as y).
-        weights : array-like, shape (n_samples,)
-            The weights of the samples.
+        output : :class:`skada.base.AdaptationOutput`
+            Dictionary-like object, with the following attributes.
+
+            X_t : array-like, shape (n_samples, n_components)
+                The data (same as X).
+            weights : array-like, shape (n_samples,)
+                The weights of the samples.
         """
         check_is_fitted(self)
         X, sample_domain = check_X_domain(X, sample_domain)
@@ -215,12 +218,13 @@ class GaussianReweightDensityAdapter(BaseAdapter):
 
         Returns
         -------
-        X_t : array-like, shape (n_samples, n_components)
-            The data (same as X).
-        y_t : array-like, shape (n_samples,)
-            The labels (same as y).
-        weights : array-like, shape (n_samples,)
-            The weights of the samples.
+        output : :class:`skada.base.AdaptationOutput`
+            Dictionary-like object, with the following attributes.
+
+            X_t : array-like, shape (n_samples, n_components)
+                The data (same as X).
+            weights : array-like, shape (n_samples,)
+                The weights of the samples.
         """
         check_is_fitted(self)
         X, sample_domain = check_X_domain(X, sample_domain)
@@ -352,12 +356,13 @@ class DiscriminatorReweightDensityAdapter(BaseAdapter):
 
         Returns
         -------
-        X_t : array-like, shape (n_samples, n_components)
-            The data (same as X).
-        y_t : array-like, shape (n_samples,)
-            The labels (same as y).
-        weights : array-like, shape (n_samples,)
-            The weights of the samples.
+        output : :class:`skada.base.AdaptationOutput`
+            Dictionary-like object, with the following attributes.
+
+            X_t : array-like, shape (n_samples, n_components)
+                The data (same as X).
+            weights : array-like, shape (n_samples,)
+                The weights of the samples.
         """
         check_is_fitted(self)
         X, sample_domain = check_X_domain(X, sample_domain)
@@ -581,12 +586,13 @@ class KLIEPAdapter(BaseAdapter):
 
         Returns
         -------
-        X_t : array-like, shape (n_samples, n_components)
-            The data (same as X).
-        y_t : array-like, shape (n_samples,)
-            The labels (same as y).
-        weights : array-like, shape (n_samples,)
-            The weights of the samples.
+        output : :class:`skada.base.AdaptationOutput`
+            Dictionary-like object, with the following attributes.
+
+            X_t : array-like, shape (n_samples, n_components)
+                The data (same as X).
+            weights : array-like, shape (n_samples,)
+                The weights of the samples.
         """
         check_is_fitted(self)
         X, sample_domain = check_X_domain(X, sample_domain)

--- a/skada/_reweight.py
+++ b/skada/_reweight.py
@@ -133,7 +133,7 @@ def ReweightDensity(
         Pipeline containing the ReweightDensity adapter and the base estimator.
     """
     if base_estimator is None:
-        base_estimator = LogisticRegression()
+        base_estimator = LogisticRegression().set_fit_request(sample_weight=True)
 
     return make_da_pipeline(
         ReweightDensityAdapter(weight_estimator=weight_estimator),
@@ -280,7 +280,7 @@ def GaussianReweightDensity(
            In Journal of Statistical Planning and Inference, 2000.
     """
     if base_estimator is None:
-        base_estimator = LogisticRegression()
+        base_estimator = LogisticRegression().set_fit_request(sample_weight=True)
 
     return make_da_pipeline(
         GaussianReweightDensityAdapter(reg=reg),
@@ -408,7 +408,7 @@ def DiscriminatorReweightDensity(
            In Journal of Statistical Planning and Inference, 2000.
     """
     if base_estimator is None:
-        base_estimator = LogisticRegression()
+        base_estimator = LogisticRegression().set_fit_request(sample_weight=True)
 
     return make_da_pipeline(
         DiscriminatorReweightDensityAdapter(
@@ -615,7 +615,7 @@ class KLIEPAdapter(BaseAdapter):
 
 
 def KLIEP(
-    base_estimator=LogisticRegression(),
+    base_estimator=None,
     gamma=1.0,
     cv=5,
     n_centers=100,
@@ -660,6 +660,8 @@ def KLIEP(
            and Its Application to Covariate Shift Adaptation.
            In NeurIPS, 2007.
     """
+    if base_estimator is None:
+        base_estimator = LogisticRegression().set_fit_request(sample_weight=True)
     return make_da_pipeline(
         KLIEPAdapter(
             gamma=gamma, cv=cv, n_centers=n_centers, tol=tol,

--- a/skada/_reweight.py
+++ b/skada/_reweight.py
@@ -110,7 +110,7 @@ class ReweightDensityAdapter(BaseAdapter):
             weights[source_idx] = source_weights
         else:
             weights = None
-        return AdaptationOutput(X=X, sample_weights=weights)
+        return AdaptationOutput(X=X, sample_weight=weights)
 
 
 def ReweightDensity(
@@ -244,7 +244,7 @@ class GaussianReweightDensityAdapter(BaseAdapter):
             weights[source_idx] = source_weights
         else:
             weights = None
-        return AdaptationOutput(X=X, sample_weights=weights)
+        return AdaptationOutput(X=X, sample_weight=weights)
 
 
 def GaussianReweightDensity(
@@ -376,7 +376,7 @@ class DiscriminatorReweightDensityAdapter(BaseAdapter):
             weights[source_idx] = source_weights
         else:
             weights = None
-        return AdaptationOutput(X=X, sample_weights=weights)
+        return AdaptationOutput(X=X, sample_weight=weights)
 
 
 def DiscriminatorReweightDensity(
@@ -611,7 +611,7 @@ class KLIEPAdapter(BaseAdapter):
             weights[source_idx] = source_weights
         else:
             weights = None
-        return AdaptationOutput(X=X, sample_weights=weights)
+        return AdaptationOutput(X=X, sample_weight=weights)
 
 
 def KLIEP(

--- a/skada/_reweight.py
+++ b/skada/_reweight.py
@@ -62,11 +62,7 @@ class ReweightDensityAdapter(BaseAdapter):
         self : object
             Returns self.
         """
-        # xxx(okachaiev): that's the reason we need a way to cache this call
-        X, sample_domain = check_X_domain(
-            X,
-            sample_domain
-        )
+        X, sample_domain = check_X_domain(X, sample_domain)
         X_source, X_target = source_target_split(X, sample_domain=sample_domain)
 
         self.weight_estimator_source_ = clone(self.weight_estimator)
@@ -96,10 +92,8 @@ class ReweightDensityAdapter(BaseAdapter):
         weights : array-like, shape (n_samples,)
             The weights of the samples.
         """
-        X, sample_domain = check_X_domain(
-            X,
-            sample_domain
-        )
+        check_is_fitted(self)
+        X, sample_domain = check_X_domain(X, sample_domain)
         source_idx = extract_source_indices(sample_domain)
 
         # xxx(okachaiev): move this to API
@@ -198,10 +192,7 @@ class GaussianReweightDensityAdapter(BaseAdapter):
         self : object
             Returns self.
         """
-        X, sample_domain = check_X_domain(
-            X,
-            sample_domain
-        )
+        X, sample_domain = check_X_domain(X, sample_domain)
         X_source, X_target = source_target_split(X, sample_domain=sample_domain)
 
         self.mean_source_ = X_source.mean(axis=0)
@@ -232,10 +223,7 @@ class GaussianReweightDensityAdapter(BaseAdapter):
             The weights of the samples.
         """
         check_is_fitted(self)
-        X, sample_domain = check_X_domain(
-            X,
-            sample_domain
-        )
+        X, sample_domain = check_X_domain(X, sample_domain)
         source_idx = extract_source_indices(sample_domain)
 
         # xxx(okachaiev): move this to API
@@ -340,17 +328,14 @@ class DiscriminatorReweightDensityAdapter(BaseAdapter):
         self : object
             Returns self.
         """
-        X, sample_domain = check_X_domain(
-            X,
-            sample_domain
-        )
+        X, sample_domain = check_X_domain(X, sample_domain)
         source_idx = extract_source_indices(sample_domain)
-
         source_idx, = np.where(source_idx)
-        self.domain_classifier_ = clone(self.domain_classifier)
         y_domain = np.ones(X.shape[0], dtype=np.int32)
         y_domain[source_idx] = 0
-        self.domain_classifier_.fit(X, y_domain)
+        domain_classifier = clone(self.domain_classifier)
+        domain_classifier.fit(X, y_domain)
+        self.domain_classifier_ = domain_classifier
         return self
 
     def adapt(self, X, y=None, sample_domain=None, **kwargs):
@@ -375,10 +360,7 @@ class DiscriminatorReweightDensityAdapter(BaseAdapter):
             The weights of the samples.
         """
         check_is_fitted(self)
-        X, sample_domain = check_X_domain(
-            X,
-            sample_domain
-        )
+        X, sample_domain = check_X_domain(X, sample_domain)
         source_idx = extract_source_indices(sample_domain)
 
         # xxx(okachaiev): move this to API
@@ -606,10 +588,8 @@ class KLIEPAdapter(BaseAdapter):
         weights : array-like, shape (n_samples,)
             The weights of the samples.
         """
-        X, sample_domain = check_X_domain(
-            X,
-            sample_domain
-        )
+        check_is_fitted(self)
+        X, sample_domain = check_X_domain(X, sample_domain)
         source_idx = extract_source_indices(sample_domain)
 
         if source_idx.sum() > 0:

--- a/skada/base.py
+++ b/skada/base.py
@@ -158,7 +158,7 @@ class BaseSelector(BaseEstimator):
         params : mapping of string to any
             Parameter names mapped to their values.
         """
-        params = self.base_estimator.get_params()
+        params = self.base_estimator.get_params(deep=deep)
         params['base_estimator'] = self.base_estimator
         return params
 

--- a/skada/base.py
+++ b/skada/base.py
@@ -252,7 +252,8 @@ class BaseSelector(BaseEstimator):
             # was accepted by the downstream (base) estimator
             if isinstance(X, AdaptationOutput):
                 for k in X:
-                    if k != 'X' and v is not None and routing_request.requests.get(k) is None:
+                    marker = routing_request.requests.get(k)
+                    if k != 'X' and v is not None and marker is None:
                         method = routing_request.method
                         raise IncompatibleMetadataError(
                             f"The adapter provided '{k}' parameter which is not explicitly set as "  # noqa
@@ -290,8 +291,8 @@ class BaseSelector(BaseEstimator):
         routed_params = {
             # this is somewhat crude way to test is `v` is indexable
             k: v[unmasked_idx] if (
-                hasattr(v, "__len__") and len(v) > len(unmasked_idx)
-                ) else v
+                hasattr(v, '__len__') and len(v) == len(unmasked_idx)
+            ) else v
             for k, v
             in routed_params.items()
         }

--- a/skada/base.py
+++ b/skada/base.py
@@ -240,7 +240,7 @@ class BaseSelector(BaseEstimator):
             params = {}
         if isinstance(X, AdaptationOutput):
             for k, v in X.items():
-                if k != 'X':
+                if k != 'X' and v is not None:
                     params[k] = v
             X_out = X['X']
         else:
@@ -252,14 +252,14 @@ class BaseSelector(BaseEstimator):
             # was accepted by the downstream (base) estimator
             if isinstance(X, AdaptationOutput):
                 for k in X:
-                    if k != 'X' and routing_request.requests.get(k) is None:
+                    if k != 'X' and v is not None and routing_request.requests.get(k) is None:
                         method = routing_request.method
                         raise IncompatibleMetadataError(
                             f"The adapter provided '{k}' parameter which is not explicitly set as "  # noqa
                             f"requested or not for '{routing_request.owner}.{method}'.\n"  # noqa
                             f"Make sure that metadata routing is properly setup, e.g. by calling 'set_{method}_request()'. "  # noqa
                             "See documentation at https://scikit-learn.org/stable/metadata_routing.html"  # noqa
-                        )
+                        ) from e
             # re-raise exception if the problem was not caused by the adapter
             raise e
         return X_out, routed_params

--- a/skada/base.py
+++ b/skada/base.py
@@ -9,6 +9,7 @@ from typing import Union
 
 import numpy as np
 from sklearn.base import BaseEstimator, clone
+from sklearn.exceptions import UnsetMetadataPassedError
 from sklearn.utils import Bunch
 from sklearn.utils.metadata_routing import get_routing_for_object
 from sklearn.utils.metaestimators import available_if
@@ -43,6 +44,20 @@ def _estimator_has(attr):
 
 class AdaptationOutput(Bunch):
     pass
+
+
+class IncompatibleMetadataError(UnsetMetadataPassedError):
+    """The exception is designated to report the situation when the adapter output
+    the key, like 'sample_weight', that is not explicitly consumed by the following
+    estimator in the pipeline.
+
+    The exception overrides :class:`~sklearn.exceptions.UnsetMetadataPassedError`
+    when there is a reason to believe that the original exception was thrown because
+    of the adapter output rather than being caused by the input to a specific function.
+    """
+
+    def __init__(self, message):
+        super().__init__(message=message, unrequested_params={}, routed_params={})
 
 
 class BaseAdapter(BaseEstimator):
@@ -220,6 +235,35 @@ class BaseSelector(BaseEstimator):
         self._is_final = True
         return self
 
+    def _route_and_merge_params(self, routing_request, X, params=None):
+        if params is None:
+            params = {}
+        if isinstance(X, AdaptationOutput):
+            for k, v in X.items():
+                if k != 'X':
+                    params[k] = v
+            X_out = X['X']
+        else:
+            X_out = X
+        try:
+            routed_params = routing_request._route_params(params=params)
+        except UnsetMetadataPassedError as e:
+            # check if every parameter given by `AdaptationOutput` object
+            # was accepted by the downstream (base) estimator
+            if isinstance(X, AdaptationOutput):
+                for k in X:
+                    if k != 'X' and routing_request.requests.get(k) is None:
+                        method = routing_request.method
+                        raise IncompatibleMetadataError(
+                            f"The adapter provided '{k}' parameter which is not explicitly set as "  # noqa
+                            f"requested or not for '{routing_request.owner}.{method}'.\n"  # noqa
+                            f"Make sure that metadata routing is properly setup, e.g. by calling 'set_{method}_request()'. "  # noqa
+                            "See documentation at https://scikit-learn.org/stable/metadata_routing.html"  # noqa
+                        )
+            # re-raise exception if the problem was not caused by the adapter
+            raise e
+        return X_out, routed_params
+
     def _remove_masked(self, X, y, routed_params):
         """Internal API for removing masked samples before passing them
         to the final estimator. Only applicable for the final estimator
@@ -262,15 +306,8 @@ class Shared(BaseSelector):
         return self.base_estimator_
 
     def fit(self, X, y, **params):
-        # xxx(okachaiev): this code is awkward, and it's duplicated everywhere
         routing = get_routing_for_object(self.base_estimator)
-        routed_params = routing.fit._route_params(params=params)
-        # xxx(okachaiev): code duplication
-        if isinstance(X, AdaptationOutput):
-            for k, v in X.items():
-                if k != 'X' and k in routed_params:
-                    routed_params[k] = v
-            X = X['X']
+        X, routed_params = self._route_and_merge_params(routing.fit, X, params)
         X, y, routed_params = self._remove_masked(X, y, routed_params)
         estimator = clone(self.base_estimator)
         estimator.fit(X, y, **routed_params)
@@ -295,12 +332,8 @@ class Shared(BaseSelector):
     # xxx(okachaiev): fail if unknown domain is given
     def _route_to_estimator(self, method_name, X, y=None, **params):
         check_is_fitted(self)
-        routed_params = getattr(self.routing_, method_name)._route_params(params=params)
-        if isinstance(X, AdaptationOutput):
-            for k, v in X.items():
-                if k != 'X' and k in routed_params:
-                    routed_params[k] = v
-            X = X['X']
+        request = getattr(self.routing_, method_name)
+        X, routed_params = self._route_and_merge_params(request, X, params)
         method = getattr(self.base_estimator_, method_name)
         output = method(X, **routed_params) if y is None else method(
             X, y, **routed_params
@@ -318,18 +351,10 @@ class PerDomain(BaseSelector):
     def fit(self, X, y, **params):
         # xxx(okachaiev): use check_*_domain to derive default domain labels
         sample_domain = params['sample_domain']
-        # xxx(okachaiev): this code is awkward, and it's duplicated everywhere
         routing = get_routing_for_object(self.base_estimator)
-        routed_params = routing.fit._route_params(params=params)
-        # xxx(okachaiev): code duplication
-        if isinstance(X, AdaptationOutput):
-            for k, v in X.items():
-                if k != 'X' and k in routed_params:
-                    routed_params[k] = v
-            X = X['X']
+        X, routed_params = self._route_and_merge_params(routing.fit, X, params)
         X, y, routed_params = self._remove_masked(X, y, routed_params)
         estimators = {}
-        # xxx(okachaiev): maybe return_index?
         for domain_label in np.unique(sample_domain):
             idx, = np.where(sample_domain == domain_label)
             estimator = clone(self.base_estimator)
@@ -345,13 +370,8 @@ class PerDomain(BaseSelector):
 
     def _route_to_estimator(self, method_name, X, y=None, **params):
         check_is_fitted(self)
-        routed_params = getattr(self.routing_, method_name)._route_params(params=params)
-        # xxx(okachaiev): again, code duplication
-        if isinstance(X, AdaptationOutput):
-            for k, v in X.items():
-                if k != 'X' and k in routed_params:
-                    routed_params[k] = v
-            X = X['X']
+        request = getattr(self.routing_, method_name)
+        X, routed_params = self._route_and_merge_params(request, X, params)
         # xxx(okachaiev): use check_*_domain to derive default domain labels
         sample_domain = params['sample_domain']
         output = None

--- a/skada/base.py
+++ b/skada/base.py
@@ -235,9 +235,7 @@ class BaseSelector(BaseEstimator):
         self._is_final = True
         return self
 
-    def _route_and_merge_params(self, routing_request, X, params=None):
-        if params is None:
-            params = {}
+    def _route_and_merge_params(self, routing_request, X, params):
         if isinstance(X, AdaptationOutput):
             for k, v in X.items():
                 if k != 'X' and v is not None:

--- a/skada/tests/test_reweight.py
+++ b/skada/tests/test_reweight.py
@@ -22,9 +22,6 @@ from skada import (
 import pytest
 
 
-# xxx(okachaiev): the problem with the pipeline being setup this way,
-#                 the estimator does not accept sample_weights (as it
-#                 doesn't request it from the routing)
 @pytest.mark.parametrize(
     "estimator",
     [

--- a/skada/tests/test_reweight.py
+++ b/skada/tests/test_reweight.py
@@ -25,15 +25,24 @@ import pytest
 @pytest.mark.parametrize(
     "estimator",
     [
-        make_da_pipeline(ReweightDensityAdapter(), LogisticRegression()),
+        make_da_pipeline(
+            ReweightDensityAdapter(),
+            LogisticRegression().set_fit_request(sample_weight=True)
+        ),
         ReweightDensity(),
-        make_da_pipeline(GaussianReweightDensityAdapter(), LogisticRegression()),
+        make_da_pipeline(
+            GaussianReweightDensityAdapter(),
+            LogisticRegression().set_fit_request(sample_weight=True)
+        ),
         GaussianReweightDensity(),
-        make_da_pipeline(DiscriminatorReweightDensityAdapter(), LogisticRegression()),
+        make_da_pipeline(
+            DiscriminatorReweightDensityAdapter(),
+            LogisticRegression().set_fit_request(sample_weight=True)
+        ),
         DiscriminatorReweightDensity(),
         make_da_pipeline(
             KLIEPAdapter(gamma=[0.1, 1], random_state=42),
-            LogisticRegression()
+            LogisticRegression().set_fit_request(sample_weight=True)
         ),
         KLIEP(gamma=[0.1, 1], random_state=42),
         KLIEP(gamma=0.2),
@@ -57,7 +66,6 @@ def test_reweight_warning(da_dataset):
         as_sources=['s'],
         as_targets=['t']
     )
-
     estimator = KLIEPAdapter(gamma=0.1, max_iter=0)
     estimator.fit(X_train, y_train, sample_domain=sample_domain)
 

--- a/skada/tests/test_scorer.py
+++ b/skada/tests/test_scorer.py
@@ -37,7 +37,11 @@ def test_generic_scorer(scorer, da_dataset):
     X, y, sample_domain = da_dataset.pack_train(as_sources=['s'], as_targets=['t'])
     estimator = make_da_pipeline(
         ReweightDensityAdapter(),
-        LogisticRegression().set_score_request(sample_weight=True),
+        LogisticRegression().set_fit_request(
+            sample_weight=True
+        ).set_score_request(
+            sample_weight=True
+        ),
     )
     cv = ShuffleSplit(n_splits=3, test_size=0.3, random_state=0)
     scores = cross_validate(
@@ -57,7 +61,11 @@ def test_supervised_scorer(da_dataset):
     X, y, sample_domain = da_dataset.pack_train(as_sources=['s'], as_targets=['t'])
     estimator = make_da_pipeline(
         ReweightDensityAdapter(),
-        LogisticRegression().set_score_request(sample_weight=True),
+        LogisticRegression().set_fit_request(
+            sample_weight=True
+        ).set_score_request(
+            sample_weight=True
+        ),
     )
     cv = ShuffleSplit(n_splits=3, test_size=0.3, random_state=0)
     _, target_labels, _ = da_dataset.pack(
@@ -87,7 +95,10 @@ def test_supervised_scorer(da_dataset):
 )
 def test_scorer_with_entropy_requires_predict_proba(scorer, da_dataset):
     X, y, sample_domain = da_dataset.pack_train(as_sources=['s'], as_targets=['t'])
-    estimator = make_da_pipeline(ReweightDensityAdapter(), SVC())
+    estimator = make_da_pipeline(
+        ReweightDensityAdapter(),
+        SVC().set_fit_request(sample_weight=True)
+    )
     estimator.fit(X, y, sample_domain=sample_domain)
     with pytest.raises(AttributeError):
         scorer(estimator, X, y, sample_domain=sample_domain)

--- a/skada/tests/test_selector.py
+++ b/skada/tests/test_selector.py
@@ -10,7 +10,12 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.utils.metadata_routing import get_routing_for_object
 
 from skada import SubspaceAlignmentAdapter, make_da_pipeline
-from skada.base import PerDomain, Shared
+from skada.base import (
+    AdaptationOutput,
+    IncompatibleMetadataError,
+    PerDomain,
+    Shared,
+)
 from skada.datasets import make_shifted_datasets
 from skada.utils import extract_source_indices
 from skada._utils import (
@@ -126,3 +131,12 @@ def test_selector_inherits_routing(estimator_cls):
     estimator = estimator_cls(lr)
     routing = get_routing_for_object(estimator)
     assert routing.fit.requests['sample_weight']
+
+
+def test_selector_rejects_incompatible_adaptation_output():
+    X = AdaptationOutput(X=np.ones(10), sample_weight=np.zeros(10))
+    y = np.zeros(10)
+    estimator = Shared(LogisticRegression())
+
+    with pytest.raises(IncompatibleMetadataError):
+        estimator.fit(X, y)

--- a/skada/tests/test_selector.py
+++ b/skada/tests/test_selector.py
@@ -5,10 +5,12 @@
 
 import numpy as np
 
-from sklearn.linear_model import LogisticRegression
 from sklearn.datasets import make_regression
+from sklearn.linear_model import LogisticRegression
+from sklearn.utils.metadata_routing import get_routing_for_object
 
 from skada import SubspaceAlignmentAdapter, make_da_pipeline
+from skada.base import PerDomain, Shared
 from skada.datasets import make_shifted_datasets
 from skada.utils import extract_source_indices
 from skada._utils import (
@@ -116,3 +118,11 @@ def test_base_selector_remove_masked_continuous():
     n_source_samples = np.sum(source_idx)
     assert X_output.shape[0] == n_source_samples, 'X output shape mismatch'
     assert X_output.shape[0] == y_output.shape[0]
+
+
+@pytest.mark.parametrize("estimator_cls", [PerDomain, Shared])
+def test_selector_inherits_routing(estimator_cls):
+    lr = LogisticRegression().set_fit_request(sample_weight=True)
+    estimator = estimator_cls(lr)
+    routing = get_routing_for_object(estimator)
+    assert routing.fit.requests['sample_weight']


### PR DESCRIPTION
Covers both #89 and #7 

Now, when we create a pipeline with the adapter that outputs `sample_weight` but the next estimator in the pipeline does not accept it, the following exception is thrown

```
E    skada.base.IncompatibleMetadataError: The adapter provided 'sample_weight' parameter which is not explicitly set as requested or not for 'LogisticRegression.fit'.
E    Make sure that metadata routing is properly setup, e.g. by calling 'set_fit_request()'. See documentation at https://scikit-learn.org/stable/metadata_routing.html
```

`IncompatibleMetadataError` overrides sklearn exception `UnsetMetadataPassedError`, when it's clear that the latter was caused by the incompatibility between adapter output and the parametrization of the estimator. All test cases are updated accordingly.