### PR TITLE
Remove target labels in the method comparison example

### DIFF
--- a/examples/plot_method_comparison.py
+++ b/examples/plot_method_comparison.py
@@ -37,8 +37,6 @@ from skada import (
     CORAL
 )
 from skada.datasets import make_shifted_datasets
-from skada import source_target_split
-from skada.datasets import DomainAwareDataset
 
 # Use same random seed for multiple calls to make_datasets to
 # ensure same distributions
@@ -84,7 +82,8 @@ datasets = [
         shift="covariate_shift",
         label="binary",
         noise=0.4,
-        random_state=RANDOM_SEED
+        random_state=RANDOM_SEED,
+        return_dataset=True
     ),
     make_shifted_datasets(
         n_samples_source=20,
@@ -92,7 +91,8 @@ datasets = [
         shift="target_shift",
         label="binary",
         noise=0.4,
-        random_state=RANDOM_SEED
+        random_state=RANDOM_SEED,
+        return_dataset=True
     ),
     make_shifted_datasets(
         n_samples_source=20,
@@ -100,7 +100,8 @@ datasets = [
         shift="concept_drift",
         label="binary",
         noise=0.4,
-        random_state=RANDOM_SEED
+        random_state=RANDOM_SEED,
+        return_dataset=True
     ),
     make_shifted_datasets(
         n_samples_source=20,
@@ -108,7 +109,8 @@ datasets = [
         shift="subspace",
         label="binary",
         noise=0.4,
-        random_state=RANDOM_SEED
+        random_state=RANDOM_SEED,
+        return_dataset=True
     ),
 ]
 
@@ -116,12 +118,9 @@ figure, axes = plt.subplots(len(classifiers) + 2, len(datasets), figsize=(9, 27)
 # iterate over datasets
 for ds_cnt, ds in enumerate(datasets):
     # preprocess dataset, split into training and test part
-    X, y, sample_domain = ds
-
-    Xs, Xt, ys, yt = source_target_split(X, y, sample_domain=sample_domain)
-
-    dataset = DomainAwareDataset([(Xs, ys, 's'), (Xt, yt, 't')])
-    X, y, sample_domain = dataset.pack_train(as_sources=['s'], as_targets=['t'])
+    X, y, sample_domain = ds.pack_train(as_sources=['s'], as_targets=['t'])
+    Xs, ys = ds.get_domain("s")
+    Xt, yt = ds.get_domain("t")
 
     x_min, x_max = X[:, 0].min() - 0.5, X[:, 0].max() + 0.5
     y_min, y_max = X[:, 1].min() - 0.5, X[:, 1].max() + 0.5

--- a/examples/plot_method_comparison.py
+++ b/examples/plot_method_comparison.py
@@ -38,6 +38,7 @@ from skada import (
 )
 from skada.datasets import make_shifted_datasets
 from skada import source_target_split
+from skada.datasets import DomainAwareDataset
 
 # Use same random seed for multiple calls to make_datasets to
 # ensure same distributions
@@ -118,6 +119,9 @@ for ds_cnt, ds in enumerate(datasets):
     X, y, sample_domain = ds
 
     Xs, Xt, ys, yt = source_target_split(X, y, sample_domain=sample_domain)
+
+    dataset = DomainAwareDataset([(Xs, ys, 's'), (Xt, yt, 't')])
+    X, y, sample_domain = dataset.pack_train(as_sources=['s'], as_targets=['t'])
 
     x_min, x_max = X[:, 0].min() - 0.5, X[:, 0].max() + 0.5
     y_min, y_max = X[:, 1].min() - 0.5, X[:, 1].max() + 0.5


### PR DESCRIPTION
Hi everyone,
I open this PR to fix a little bug in the `plot_method_comparison.py` example. Target labels were given to the fit methods, they are now removed (cf. #83).

The reweighting method are still not working, but it should be resolved soon, with PR #90