### PR TITLE
[ON_HOLD] Additional utility helper to check structure of the `sample_domain` array

### DIFF
--- a/skada/__init__.py
+++ b/skada/__init__.py
@@ -9,6 +9,7 @@ import sklearn
 from .version import __version__  # noqa: F401
 from . import model_selection
 from . import metrics
+from . import utils
 from .base import BaseAdapter, PerDomain, Shared
 from ._mapping import (
     ClassRegularizerOTMappingAdapter,
@@ -50,6 +51,7 @@ sklearn.set_config(enable_metadata_routing=True)
 __all__ = [
     "metrics",
     "model_selection",
+    "utils",
 
     "BaseAdapter",
     "PerDomain",

--- a/skada/tests/test_cv.py
+++ b/skada/tests/test_cv.py
@@ -149,14 +149,14 @@ def test_stratified_domain_shuffle_split_exceptions():
     # Test with y.ndim == 2 nothing is raised
     X = np.ones((10, 2))
     y = np.array(5*[[0], [1]])
-    sample_domain = np.array(5*[0, 1])
+    sample_domain = np.array(5*[-2, 1])
     splitter = StratifiedDomainShuffleSplit(n_splits=4, test_size=0.5, random_state=0)
     next(iter((splitter.split(X, y, sample_domain))))
 
     # Test np.min(group_counts) < 2
     X = np.ones((2, 2))
     y = np.array([0, 1])
-    sample_domain = np.array([0, 1])
+    sample_domain = np.array([-2, 1])
     splitter = StratifiedDomainShuffleSplit(n_splits=4, test_size=0.5, random_state=0)
     with pytest.raises(ValueError):
         next(iter((splitter.split(X, y, sample_domain))))
@@ -164,7 +164,7 @@ def test_stratified_domain_shuffle_split_exceptions():
     # Test n_train < n_groups:
     X = np.ones((10, 2))
     y = np.array(5*[0, 1])
-    sample_domain = np.array(5*[0, 1])
+    sample_domain = np.array(5*[-2, 1])
     splitter = StratifiedDomainShuffleSplit(n_splits=4, test_size=0.9, random_state=0)
     with pytest.raises(ValueError):
         next(iter((splitter.split(X, y, sample_domain))))
@@ -172,7 +172,7 @@ def test_stratified_domain_shuffle_split_exceptions():
     # Test n_test < n_groups:
     X = np.ones((10, 2))
     y = np.array(5*[0, 1])
-    sample_domain = np.array(5*[0, 1])
+    sample_domain = np.array(5*[-2, 1])
     splitter = StratifiedDomainShuffleSplit(n_splits=4, test_size=0.1, random_state=0)
     with pytest.raises(ValueError):
         next(iter((splitter.split(X, y, sample_domain))))

--- a/skada/tests/test_utils.py
+++ b/skada/tests/test_utils.py
@@ -149,9 +149,13 @@ def test_check_X_y_allow_exceptions():
 
     positive_numbers = random_sample_domain[random_sample_domain > 0]
     negative_numbers = random_sample_domain[random_sample_domain < 0]
-    # Count unique positive numbers
+
+    # Count number of sources and targets
     n_sources = len(np.unique(positive_numbers))
     n_targets = len(np.unique(negative_numbers))
+
+    # Adjust targets to avoid sample_domain checker raise issues
+    random_sample_domain[random_sample_domain < 0] -= (n_sources + 1)
 
     with pytest.raises(
         ValueError,
@@ -170,7 +174,7 @@ def test_check_X_y_allow_exceptions():
         match=(
             f"Number of targets provided is {n_targets} "
             f"and 'allow_target' is set to {allow_target}"
-            )
+        )
     ):
         check_X_y_domain(
             X, y, sample_domain=random_sample_domain,
@@ -225,9 +229,12 @@ def test_check_X_allow_exceptions():
     positive_numbers = random_sample_domain[random_sample_domain > 0]
     negative_numbers = random_sample_domain[random_sample_domain < 0]
 
-    # Count unique positive numbers
+    # Count number of sources and targets
     n_sources = len(np.unique(positive_numbers))
     n_targets = len(np.unique(negative_numbers))
+
+    # Adjust targets to avoid sample_domain checker raise issues
+    random_sample_domain[random_sample_domain < 0] -= (n_sources + 1)
 
     with pytest.raises(
         ValueError,
@@ -237,8 +244,10 @@ def test_check_X_allow_exceptions():
         )
     ):
         check_X_domain(
-            X, sample_domain=random_sample_domain,
-            allow_auto_sample_domain=False, allow_source=allow_source
+            X,
+            sample_domain=random_sample_domain,
+            allow_auto_sample_domain=False,
+            allow_source=allow_source
         )
 
     with pytest.raises(
@@ -249,8 +258,10 @@ def test_check_X_allow_exceptions():
         )
     ):
         check_X_domain(
-            X, sample_domain=random_sample_domain,
-            allow_auto_sample_domain=False, allow_target=allow_target
+            X,
+            sample_domain=random_sample_domain,
+            allow_auto_sample_domain=False,
+            allow_target=allow_target
         )
 
     with pytest.raises(
@@ -261,8 +272,10 @@ def test_check_X_allow_exceptions():
         )
     ):
         check_X_domain(
-            X, sample_domain=random_sample_domain,
-            allow_auto_sample_domain=False, allow_multi_source=allow_multi_source
+            X,
+            sample_domain=random_sample_domain,
+            allow_auto_sample_domain=False,
+            allow_multi_source=allow_multi_source
         )
 
     with pytest.raises(
@@ -273,8 +286,10 @@ def test_check_X_allow_exceptions():
         )
     ):
         check_X_domain(
-            X, sample_domain=random_sample_domain,
-            allow_auto_sample_domain=False, allow_multi_target=allow_multi_target
+            X,
+            sample_domain=random_sample_domain,
+            allow_auto_sample_domain=False,
+            allow_multi_target=allow_multi_target
         )
 
 
@@ -343,19 +358,21 @@ def test_source_target_merge():
     )
 
     # Test consistent length
-    with pytest.raises(ValueError,
-                       match="Inconsistent number of samples in source-target arrays "
-                       "and the number infered in the sample_domain"
-                       ):
+    with pytest.raises(
+        ValueError,
+        match="Inconsistent number of samples in source-target arrays "
+              "and the number infered in the sample_domain"
+    ):
         _ = source_target_merge(X_source[0], X_target[1], sample_domain=sample_domain)
 
     # Test no sample domain
     _ = source_target_merge(X_source, X_target, sample_domain=None)
 
     # Test odd number of array
-    with pytest.raises(ValueError,
-                       match="Even number of arrays required as input"
-                       ):
+    with pytest.raises(
+        ValueError,
+        match="Even number of arrays required as input"
+    ):
         _ = source_target_merge(
             X_source,
             X_target,
@@ -373,16 +390,18 @@ def test_source_target_merge():
     )
 
     # Test one array
-    with pytest.raises(ValueError,
-                       match="At least two array required as input"
-                       ):
+    with pytest.raises(
+        ValueError,
+        match="At least two array required as input"
+    ):
         _ = source_target_merge(X_source, sample_domain=sample_domain)
 
     # Test y_target = None + Inconsistent number of samples in source-target
-    with pytest.raises(ValueError,
-                       match="Inconsistent number of samples in source-target arrays "
-                       "and the number infered in the sample_domain"
-                       ):
+    with pytest.raises(
+        ValueError,
+        match="Inconsistent number of samples in source-target arrays "
+              "and the number infered in the sample_domain"
+    ):
         _ = source_target_merge(
             X_source,
             X_target,
@@ -401,18 +420,20 @@ def test_source_target_merge():
     )
 
     # Test 2 None in a pair of arrays
-    with pytest.raises(ValueError,
-                       match="Only one array can be None or empty in each pair"
-                       ):
+    with pytest.raises(
+        ValueError,
+        match="Only one array can be None or empty in each pair"
+    ):
         _ = source_target_merge(None, None, sample_domain=sample_domain)
 
     # Test 1 None in 2 pair of arrays
     _ = source_target_merge(X_source, None, y_source, None, sample_domain=sample_domain)
 
     # Test inconsistent number of features
-    with pytest.raises(ValueError,
-                       match="Inconsistent number of features in source-target arrays"
-                       ):
+    with pytest.raises(
+        ValueError,
+        match="Inconsistent number of features in source-target arrays"
+    ):
         _ = source_target_merge(
             X_source[:, :-1],
             X_target,

--- a/skada/tests/test_utils.py
+++ b/skada/tests/test_utils.py
@@ -10,6 +10,7 @@ from skada.datasets import (
     make_dataset_from_moons_distribution
 )
 from skada.utils import (
+    check_sample_domain,
     check_X_y_domain,
     check_X_domain,
     extract_source_indices,
@@ -439,3 +440,12 @@ def test_source_target_merge():
             X_target,
             sample_domain=sample_domain
         )
+
+
+def test_check_sample_domain_lodo():
+    # same domain label added twice (as a source and as a target)
+    check_sample_domain(np.array([1, 1, 2, 2, 2, -1, -1, -2, -2, -2]))
+
+    # 'lodo' packing but counters are off
+    with pytest.raises(ValueError):
+        check_sample_domain(np.array([1, 1, -1, 2, 2, 2, -2, -2]))

--- a/skada/utils.py
+++ b/skada/utils.py
@@ -199,10 +199,10 @@ def check_X_domain(
 def check_sample_domain(sample_domain):
     """Validate `sample_domain` parameter for domain adaptation.
 
-    Valid `sample_domain` array contains each index either as a
+    Valid `sample_domain` array contains each domain label either as a
     source (positive) or as a target (negative). The only exception,
     as of now, is 'lodo' (Leave-One-Domain-Out) packing that contains
-    each index twice (both as positive and negative).
+    each domain label twice (both as positive and negative).
 
     Parameters:
     -----------


### PR DESCRIPTION
The checker makes sure that each domain label is used either as a source or as a target, except for the 'lodo' packing (for which we check that subsets are of the equal size).