### PR TITLE
Update `AdaptationOutput` to make `X` into an attribute

### DIFF
--- a/skada/_reweight.py
+++ b/skada/_reweight.py
@@ -90,9 +90,9 @@ class ReweightDensityAdapter(BaseAdapter):
         output : :class:`skada.base.AdaptationOutput`
             Dictionary-like object, with the following attributes.
 
-            X_t : array-like, shape (n_samples, n_components)
+            X : array-like, shape (n_samples, n_components)
                 The data (same as X).
-            weights : array-like, shape (n_samples,)
+            sample_weight : array-like, shape (n_samples,)
                 The weights of the samples.
         """
         check_is_fitted(self)
@@ -110,7 +110,7 @@ class ReweightDensityAdapter(BaseAdapter):
             weights[source_idx] = source_weights
         else:
             weights = None
-        return AdaptationOutput(X=X, sample_weight=weights)
+        return AdaptationOutput(X, sample_weight=weights)
 
 
 def ReweightDensity(
@@ -221,9 +221,9 @@ class GaussianReweightDensityAdapter(BaseAdapter):
         output : :class:`skada.base.AdaptationOutput`
             Dictionary-like object, with the following attributes.
 
-            X_t : array-like, shape (n_samples, n_components)
+            X : array-like, shape (n_samples, n_components)
                 The data (same as X).
-            weights : array-like, shape (n_samples,)
+            sample_weight : array-like, shape (n_samples,)
                 The weights of the samples.
         """
         check_is_fitted(self)
@@ -244,7 +244,7 @@ class GaussianReweightDensityAdapter(BaseAdapter):
             weights[source_idx] = source_weights
         else:
             weights = None
-        return AdaptationOutput(X=X, sample_weight=weights)
+        return AdaptationOutput(X, sample_weight=weights)
 
 
 def GaussianReweightDensity(
@@ -359,9 +359,9 @@ class DiscriminatorReweightDensityAdapter(BaseAdapter):
         output : :class:`skada.base.AdaptationOutput`
             Dictionary-like object, with the following attributes.
 
-            X_t : array-like, shape (n_samples, n_components)
+            X : array-like, shape (n_samples, n_components)
                 The data (same as X).
-            weights : array-like, shape (n_samples,)
+            sample_weight : array-like, shape (n_samples,)
                 The weights of the samples.
         """
         check_is_fitted(self)
@@ -376,7 +376,7 @@ class DiscriminatorReweightDensityAdapter(BaseAdapter):
             weights[source_idx] = source_weights
         else:
             weights = None
-        return AdaptationOutput(X=X, sample_weight=weights)
+        return AdaptationOutput(X, sample_weight=weights)
 
 
 def DiscriminatorReweightDensity(
@@ -589,9 +589,9 @@ class KLIEPAdapter(BaseAdapter):
         output : :class:`skada.base.AdaptationOutput`
             Dictionary-like object, with the following attributes.
 
-            X_t : array-like, shape (n_samples, n_components)
+            X : array-like, shape (n_samples, n_components)
                 The data (same as X).
-            weights : array-like, shape (n_samples,)
+            sample_weight : array-like, shape (n_samples,)
                 The weights of the samples.
         """
         check_is_fitted(self)
@@ -611,7 +611,7 @@ class KLIEPAdapter(BaseAdapter):
             weights[source_idx] = source_weights
         else:
             weights = None
-        return AdaptationOutput(X=X, sample_weight=weights)
+        return AdaptationOutput(X, sample_weight=weights)
 
 
 def KLIEP(

--- a/skada/base.py
+++ b/skada/base.py
@@ -43,7 +43,11 @@ def _estimator_has(attr):
 
 
 class AdaptationOutput(Bunch):
-    pass
+    """Container object for multi-key adaptation output."""
+
+    def __init__(self, X, **kwargs):
+        self.X = X
+        super().__init__(**kwargs)
 
 
 class IncompatibleMetadataError(UnsetMetadataPassedError):
@@ -273,23 +277,23 @@ class BaseSelector(BaseEstimator):
         self._is_final = False
         return self
 
-    def _route_and_merge_params(self, routing_request, X, params):
-        if isinstance(X, AdaptationOutput):
-            for k, v in X.items():
-                if k != 'X' and v is not None:
+    def _route_and_merge_params(self, routing_request, X_input, params):
+        if isinstance(X_input, AdaptationOutput):
+            X_out = X_input.X
+            for k, v in X_input.items():
+                if v is not None:
                     params[k] = v
-            X_out = X['X']
         else:
-            X_out = X
+            X_out = X_input
         try:
             routed_params = routing_request._route_params(params=params)
         except UnsetMetadataPassedError as e:
             # check if every parameter given by `AdaptationOutput` object
             # was accepted by the downstream (base) estimator
-            if isinstance(X, AdaptationOutput):
-                for k in X:
+            if isinstance(X_input, AdaptationOutput):
+                for k in X_input:
                     marker = routing_request.requests.get(k)
-                    if k != 'X' and v is not None and marker is None:
+                    if v is not None and marker is None:
                         method = routing_request.method
                         raise IncompatibleMetadataError(
                             f"The adapter provided '{k}' parameter which is not explicitly set as "  # noqa

--- a/skada/tests/test_selector.py
+++ b/skada/tests/test_selector.py
@@ -134,7 +134,7 @@ def test_selector_inherits_routing(estimator_cls):
 
 
 def test_selector_rejects_incompatible_adaptation_output():
-    X = AdaptationOutput(X=np.ones(10), sample_weight=np.zeros(10))
+    X = AdaptationOutput(np.ones(10), sample_weight=np.zeros(10))
     y = np.zeros(10)
     estimator = Shared(LogisticRegression())
 

--- a/skada/tests/test_subspace.py
+++ b/skada/tests/test_subspace.py
@@ -77,5 +77,5 @@ def test_subspace_default_n_components(adapter, n_samples, n_features, n_compone
     X_test, _, sample_domain = dataset.pack_test(as_targets=['t'])
     output = adapter.transform(X_test, sample_domain=sample_domain)
     if isinstance(output, AdaptationOutput):
-        output = output['X']
+        output = output.X
     assert output.shape[1] == n_components


### PR DESCRIPTION
* cleanup code for adaptation output processing by moving `X` to an attribute instead of keys
* fix documentation for reweight adapters ('returns' section of docstrings)