### PR TITLE
Remove masked inputs only if estimator does not accept `sample_domain`

### DIFF
--- a/skada/tests/test_pipeline.py
+++ b/skada/tests/test_pipeline.py
@@ -63,11 +63,11 @@ def test_per_domain_selector():
     scaler.fit(X, None, sample_domain=sample_domain)
     assert_array_equal(
         np.array([[-3., 1.]]),
-        scaler.transform(np.array([[-1., 1.]]), sample_domain=[1])
+        scaler.transform(np.array([[-1., 1.]]), sample_domain=np.array([1]))
     )
     assert_array_equal(
         np.array([[-1., -0.75]]),
-        scaler.transform(np.array([[-1., 1.]]), sample_domain=[2])
+        scaler.transform(np.array([[-1., 1.]]), sample_domain=np.array([2]))
     )
 
 


### PR DESCRIPTION
Per the discussion in Slack.

`Selector` now removes masked inputs if the base estimator does not accept `sample_domain` through the routing (e.g. any sklearn estimator out there). The contract is that if the estimator declares `sample_domain` as a parameter, it should be able to deal with inputs being partially masked (presumably targets).  