### PR TITLE
[MRG] Implement CircularValidation as a scorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ estimator and an `Adapter` that can be used in a DA pipeline with
 - Prediction entropy [18]
 - Soft neighborhood density [19]
 - Deep Embedded Validation (DEV) [20]
+- Circular Validation [21]
 
 
 ## Installation
@@ -191,4 +192,4 @@ The library is distributed under the 3-Clause BSD license.
 
 [20] You, K., Wang, X., Long, M., & Jordan, M. (2019, May). [Towards accurate model selection in deep unsupervised domain adaptation](https://proceedings.mlr.press/v97/you19a/you19a.pdf). In International Conference on Machine Learning (pp. 7124-7133). PMLR.
 
-[21] Domain Adaptation Problems: A DASVM ClassificationTechnique and a Circular Validation StrategyLorenzo Bruzzone, Fellow, IEEE, and Mattia Marconcini, Member, IEEE (https://rslab.disi.unitn.it/papers/R82-PAMI.pdf)
+[21] Bruzzone, Lorenzo & Marconcini, Mattia. (2010). [Domain Adaptation Problems: A DASVM Classification Technique and a Circular Validation Strategy](https://rslab.disi.unitn.it/papers/R82-PAMI.pdf). IEEE transactions on pattern analysis and machine intelligence. 32. 770-87. 10.1109/TPAMI.2009.57. 

--- a/docs/source/all.rst
+++ b/docs/source/all.rst
@@ -118,6 +118,7 @@ DA metrics :py:mod:`skada.metrics`
    PredictionEntropyScorer
    DeepEmbeddedValidation
    SoftNeighborhoodDensity
+   CircularValidation
 
 
 Model Selection :py:mod:`skada.model_selection`

--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -427,7 +427,13 @@ class DeepEmbeddedValidation(_BaseDomainAwareScorer):
 class CircularValidation(_BaseDomainAwareScorer):
     """Score based on a circular validation strategy.
 
-    See [1]_ for details.
+    This scorer retrain the estimator, with the exact same parameters,
+    on the predicted target domain samples. Then, the retrained estimator
+    is used to predict the source domain labels. The score is then
+    computed using the source_scorer between the true source labels and
+    the predicted source labels.
+
+    See [21]_ for details.
 
     Parameters
     ----------
@@ -441,7 +447,7 @@ class CircularValidation(_BaseDomainAwareScorer):
 
     References
     ----------
-    .. [1]  Bruzzone, Lorenzo & Marconcini, Mattia.
+    .. [21]  Bruzzone, Lorenzo & Marconcini, Mattia.
             Domain Adaptation Problems: A DASVM Classification Technique
             and a Circular Validation Strategy. IEEE, 2010.
     """
@@ -449,7 +455,6 @@ class CircularValidation(_BaseDomainAwareScorer):
     def __init__(
         self,
         source_scorer=balanced_accuracy_score,
-        random_state=None,
         greater_is_better=True,
     ):
         super().__init__()
@@ -460,7 +465,6 @@ class CircularValidation(_BaseDomainAwareScorer):
             )
 
         self.source_scorer = source_scorer
-        self.random_state = random_state
         self._sign = 1 if greater_is_better else -1
 
     def _score(self, estimator, X, y, sample_domain=None):

--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -1,6 +1,7 @@
 # Author: Theo Gnassounou <theo.gnassounou@inria.fr>
 #         Remi Flamary <remi.flamary@polytechnique.edu>
 #         Oleksii Kachaiev <kachayev@gmail.com>
+#         Yanis Lalou <yanis.lalou@polytechnique.edu>
 #
 # License: BSD 3-Clause
 
@@ -439,9 +440,9 @@ class CircularValidation(_BaseDomainAwareScorer):
 
     References
     ----------
-    .. [1]  Lorenzo Bruzzone. Domain Adaptation Problems:
-            A DASVM Classification Technique and a Circular Validation Strategy
-            IEEE, 2010.
+    .. [1]  Bruzzone, Lorenzo & Marconcini, Mattia.
+            Domain Adaptation Problems: A DASVM Classification Technique
+            and a Circular Validation Strategy. IEEE, 2010.
     """
 
     def __init__(

--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -24,7 +24,8 @@ from .utils import check_X_y_domain, extract_source_indices, source_target_split
 from ._utils import _find_y_type
 from ._utils import (
     _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL,
-    _DEFAULT_MASKED_TARGET_REGRESSION_LABEL
+    _DEFAULT_MASKED_TARGET_REGRESSION_LABEL,
+    Y_Type,
 )
 
 
@@ -512,7 +513,7 @@ class CircularValidation(_BaseDomainAwareScorer):
             backward_y[~source_idx] = y_pred_target
 
             y_type = _find_y_type(y[source_idx])
-            if y_type == 'classification':
+            if y_type == Y_Type.DISCRETE:
                 backward_y[source_idx] = _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL
             else:
                 backward_y[source_idx] = _DEFAULT_MASKED_TARGET_REGRESSION_LABEL

--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -5,6 +5,7 @@
 # License: BSD 3-Clause
 
 from abc import abstractmethod
+import warnings
 import numpy as np
 
 from sklearn.base import clone
@@ -16,8 +17,14 @@ from sklearn.preprocessing import Normalizer
 from sklearn.utils import check_random_state
 from sklearn.utils.extmath import softmax
 from sklearn.utils.metadata_routing import _MetadataRequester, get_routing_for_object
+from sklearn.metrics import balanced_accuracy_score
 
 from .utils import check_X_y_domain, extract_source_indices, source_target_split
+from ._utils import _find_y_type
+from ._utils import (
+    _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL,
+    _DEFAULT_MASKED_TARGET_REGRESSION_LABEL
+)
 
 
 # xxx(okachaiev): maybe it would be easier to reuse _BaseScorer?
@@ -413,3 +420,104 @@ class DeepEmbeddedValidation(_BaseDomainAwareScorer):
         var_w = np.var(weights, ddof=1)
         eta = -cov / var_w
         return self._sign * (np.mean(weighted_error) + eta * np.mean(weights) - eta)
+
+
+class CircularValidation(_BaseDomainAwareScorer):
+    """Score based on a circular validation strategy.
+
+    See [1]_ for details.
+
+    Parameters
+    ----------
+    source_scorer : callable, default = `sklearn.metrics.balanced_accuracy_score`
+        Scorer used on the source domain samples.
+        It should be a callable of the form `source_scorer(y, y_pred)`.
+    greater_is_better : bool, default=False
+        Whether `scorer` is a score function (default), meaning high is
+        good, or a loss function, meaning low is good. In the latter case, the
+        scorer object will sign-flip the outcome of the `scorer`.
+
+    References
+    ----------
+    .. [1]  Lorenzo Bruzzone. Domain Adaptation Problems:
+            A DASVM Classification Technique and a Circular Validation Strategy
+            IEEE, 2010.
+    """
+
+    def __init__(
+        self,
+        source_scorer=balanced_accuracy_score,
+        random_state=None,
+        greater_is_better=True,
+    ):
+        super().__init__()
+        if not callable(source_scorer):
+            raise ValueError(
+                "The source scorer should be a callable. "
+                f"The scorer {self.source_scorer!r} is not."
+            )
+
+        self.source_scorer = source_scorer
+        self.random_state = random_state
+        self._sign = 1 if greater_is_better else -1
+
+    def _score(self, estimator, X, y, sample_domain=None):
+        """
+        Compute the score based on a circular validation strategy.
+
+        Parameters
+        ----------
+        estimator : object
+            A trained estimator.
+        X : array-like or sparse matrix
+            The input samples.
+        y : array-like
+            The true labels.
+        sample_domain : array-like, default=None
+            Domain labels for each sample.
+
+        Returns
+        -------
+        float
+            The computed score.
+        """
+        X, y, sample_domain = check_X_y_domain(X, y, sample_domain)
+        source_idx = extract_source_indices(sample_domain)
+
+        backward_estimator = clone(estimator)
+
+        y_pred_target = estimator.predict(X[~source_idx])
+
+        if len(np.unique(y_pred_target)) == 1:
+            warnings.warn(
+                "The predicted target domain labels"
+                "are all the same. "
+                "The score will be 0."
+            )
+            # Otherwise, we can get ValueError exceptions
+            # when fitting the backward estimator
+            # (happened with SVC)
+            return 0
+
+        backward_sample_domain = -sample_domain
+
+        backward_y = np.zeros_like(y)
+        backward_y[~source_idx] = y_pred_target
+
+        y_type = _find_y_type(y[source_idx])
+        if y_type == 'classification':
+            backward_y[source_idx] = _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL
+        else:
+            backward_y[source_idx] = _DEFAULT_MASKED_TARGET_REGRESSION_LABEL
+
+        print(np.unique(backward_y))
+        print(np.unique(backward_y[source_idx]))
+        print(np.unique(backward_y[~source_idx]))
+        print(np.unique(backward_sample_domain[source_idx]))
+        print(np.unique(backward_sample_domain[~source_idx]))
+        backward_estimator.fit(X, backward_y, sample_domain=backward_sample_domain)
+        y_pred_source = backward_estimator.predict(X[source_idx])
+
+        score = self.source_scorer(y[source_idx], y_pred_source)
+
+        return self._sign * score

--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -510,11 +510,6 @@ class CircularValidation(_BaseDomainAwareScorer):
         else:
             backward_y[source_idx] = _DEFAULT_MASKED_TARGET_REGRESSION_LABEL
 
-        print(np.unique(backward_y))
-        print(np.unique(backward_y[source_idx]))
-        print(np.unique(backward_y[~source_idx]))
-        print(np.unique(backward_sample_domain[source_idx]))
-        print(np.unique(backward_sample_domain[~source_idx]))
         backward_estimator.fit(X, backward_y, sample_domain=backward_sample_domain)
         y_pred_source = backward_estimator.predict(X[source_idx])
 

--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -455,7 +455,7 @@ class CircularValidation(_BaseDomainAwareScorer):
         if not callable(source_scorer):
             raise ValueError(
                 "The source scorer should be a callable. "
-                f"The scorer {self.source_scorer!r} is not."
+                f"The scorer {source_scorer} is not."
             )
 
         self.source_scorer = source_scorer

--- a/skada/tests/test_scorer.py
+++ b/skada/tests/test_scorer.py
@@ -213,6 +213,9 @@ def test_circular_validation(da_dataset):
     )
     estimator_regression.fit(X, y, sample_domain=sample_domain)
 
-    scorer = CircularValidation(source_scorer=mean_squared_error)
+    scorer = CircularValidation(
+        source_scorer=mean_squared_error,
+        greater_is_better=False
+    )
     score = scorer._score(estimator_regression, X, y, sample_domain=sample_domain)
     assert ~np.isnan(score), "the score is computed"

--- a/skada/tests/test_scorer.py
+++ b/skada/tests/test_scorer.py
@@ -1,20 +1,23 @@
 # Author: Theo Gnassounou <theo.gnassounou@inria.fr>
 #         Remi Flamary <remi.flamary@polytechnique.edu>
 #         Oleksii Kachaiev <kachayev@gmail.com>
+#         Yanis Lalou <yanis.lalou@polytechnique.edu>
 #
 # License: BSD 3-Clause
 
 import numpy as np
-from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import LogisticRegression, LinearRegression
+from sklearn.metrics import mean_squared_error
 from sklearn.model_selection import ShuffleSplit, cross_validate
 from sklearn.svm import SVC
+from sklearn.dummy import DummyRegressor
 
 from skada import (
     ReweightDensityAdapter,
     SubspaceAlignmentAdapter,
     make_da_pipeline,
 )
-from skada.datasets import DomainAwareDataset
+from skada.datasets import DomainAwareDataset, make_shifted_datasets
 from skada.metrics import (
     SupervisedScorer,
     ImportanceWeightedScorer,
@@ -165,3 +168,51 @@ def test_prediction_entropy_scorer_reduction(da_dataset):
         scorer = PredictionEntropyScorer(reduction='none')
         scorer.reduction = 'WRONG_REDUCTION'
         scorer._score(estimator, X, y, sample_domain=sample_domain)
+
+
+def test_circular_validation(da_dataset):
+    X, y, sample_domain = da_dataset.pack_train(as_sources=['s'], as_targets=['t'])
+    estimator = make_da_pipeline(
+        ReweightDensityAdapter(),
+        LogisticRegression().set_fit_request(
+            sample_weight=True
+        ),
+    )
+
+    estimator.fit(X, y, sample_domain=sample_domain)
+
+    scorer = CircularValidation()
+    score = scorer._score(estimator, X, y, sample_domain=sample_domain)
+    assert ~np.isnan(score), "the score is computed"
+
+    # Test not callable source_scorer
+    with pytest.raises(ValueError):
+        scorer = CircularValidation(source_scorer=None)
+
+    # Test unique y_pred_target
+    estimator_dummy = make_da_pipeline(
+        DummyRegressor(strategy="constant", constant=1),
+    )
+    estimator_dummy.fit(X, y, sample_domain=sample_domain)
+    scorer = CircularValidation()
+    score = scorer._score(estimator_dummy, X, y, sample_domain=sample_domain)
+    assert ~np.isnan(score), "the score is computed"
+
+    # Test regression task
+    X, y, sample_domain = make_shifted_datasets(
+        n_samples_source=10,
+        n_samples_target=10,
+        noise=None,
+        label="regression",
+    )
+    estimator_regression = make_da_pipeline(
+        ReweightDensityAdapter(),
+        LinearRegression().set_fit_request(
+            sample_weight=True
+        ),
+    )
+    estimator_regression.fit(X, y, sample_domain=sample_domain)
+
+    scorer = CircularValidation(source_scorer=mean_squared_error)
+    score = scorer._score(estimator_regression, X, y, sample_domain=sample_domain)
+    assert ~np.isnan(score), "the score is computed"

--- a/skada/tests/test_scorer.py
+++ b/skada/tests/test_scorer.py
@@ -20,6 +20,7 @@ from skada.metrics import (
     ImportanceWeightedScorer,
     PredictionEntropyScorer,
     SoftNeighborhoodDensity,
+    CircularValidation,
 )
 
 import pytest
@@ -31,6 +32,7 @@ import pytest
         ImportanceWeightedScorer(),
         PredictionEntropyScorer(),
         SoftNeighborhoodDensity(),
+        CircularValidation(),
     ],
 )
 def test_generic_scorer(scorer, da_dataset):


### PR DESCRIPTION
Fixes #111 
Paper: https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=4803844&tag=1
Process described in part [5] and [6].

Small thing not in the paper but implemented:
- If the estimator predicts always the same value, then we assume that the `backward_estimator` will also predicts  always the same value.

--> Why? Because for some estimators, if you train them with np.unique(y) = 1 you get ValueErrors (happens with SVC).