### PR TITLE
No need for mark-as-final operation

### DIFF
--- a/skada/_pipeline.py
+++ b/skada/_pipeline.py
@@ -93,18 +93,13 @@ def make_da_pipeline(
                 if name is not None:
                     nested_name = f"{name}__{nested_name}"
                 names.append(nested_name)
-                # the final mark is gonna be added later
-                # overall, if we have marked as final estimator as it is not
-                # the final one in the unrolled (un-nested) pipeline, we are
-                # likely doing something wrong
-                estimators.append(nested_selector._unmark_as_final())
+                estimators.append(nested_selector)
         else:
             names.append(name)
             estimators.append(estimator)
 
     wrapped_estimators = _wrap_with_selectors(estimators, default_selector)
     steps = _name_estimators(wrapped_estimators)
-    steps[-1][1]._mark_as_final()
     named_steps = [
         (auto_name, step) if user_name is None else (user_name, step)
         for user_name, (auto_name, step) in zip(names, steps)

--- a/skada/base.py
+++ b/skada/base.py
@@ -177,7 +177,6 @@ class BaseSelector(BaseEstimator, _DAMetadataRequesterMixin):
         super().__init__()
         self.base_estimator = base_estimator
         self.base_estimator.set_params(**kwargs)
-        self._is_final = False
 
     def get_metadata_routing(self):
         return (
@@ -272,25 +271,6 @@ class BaseSelector(BaseEstimator, _DAMetadataRequesterMixin):
     @available_if(_estimator_has('score'))
     def score(self, X, y, **params):
         return self._route_to_estimator('score', X, y=y, **params)
-
-    def _mark_as_final(self) -> 'BaseSelector':
-        """Internal API for keeping track of which estimator is final
-        in the Pipeline.
-
-        Marks estimator as final.
-        """
-        self._is_final = True
-        return self
-
-    def _unmark_as_final(self) -> 'BaseSelector':
-        """Internal API for keeping track of which estimator is final
-        in the Pipeline.
-
-        Removes previously set mark indicating that the estimator added
-        as final.
-        """
-        self._is_final = False
-        return self
 
     def _route_and_merge_params(self, routing_request, X_input, params):
         if isinstance(X_input, AdaptationOutput):


### PR DESCRIPTION
With #123 being merged the selector does not check if estimator was 'final' in the pipeline. Thus the API for marking is not needed.