### PR TITLE
Selector to avoid filtering out masked samples when fitting transformer

### DIFF
--- a/skada/_utils.py
+++ b/skada/_utils.py
@@ -144,11 +144,6 @@ def _remove_masked(X, y, params):
     params : dict
         Additional parameters declared in the routing
     """
-    # technically, `y` is optional but if we have no
-    # labels, - there are no masks
-    if y is None:
-        return X, y, params
-
     y_type = _find_y_type(y)
     if y_type == Y_Type.DISCRETE:
         unmasked_idx = (y != _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL)

--- a/skada/tests/test_selector.py
+++ b/skada/tests/test_selector.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 
+from sklearn.base import BaseEstimator
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LogisticRegression
 from sklearn.utils.metadata_routing import get_routing_for_object
@@ -50,7 +51,7 @@ def test_base_selector_estimator_fetcher():
     assert isinstance(selector.get_estimator(), LogisticRegression)
 
 
-def test_base_selector_remove_masked():
+def test_remove_masked_helper():
     n_samples = 10
     X, y, sample_domain = make_shifted_datasets(
         n_samples_source=n_samples,
@@ -75,19 +76,52 @@ def test_base_selector_remove_masked():
 
 
 @pytest.mark.parametrize('step', [SubspaceAlignmentAdapter(), LogisticRegression()])
-def test_base_selector_remove_masked_transform(step):
+def test_base_selector_remove_masked(step):
     n_samples = 10
-    X, y, sample_domain = make_shifted_datasets(
+    dataset = make_shifted_datasets(
         n_samples_source=n_samples,
         n_samples_target=n_samples,
         shift='concept_drift',
         noise=0.1,
         random_state=42,
+        return_dataset=True,
     )
+    X, y, sample_domain = dataset.pack_train(as_sources=['s'], as_targets=['t'])
 
     pipe = make_da_pipeline(step)
     # no ValueError is raised
     pipe.fit(X=X, y=y, sample_domain=sample_domain)
+
+
+def test_base_selector_no_filtering_transformer():
+    dataset = make_shifted_datasets(
+        n_samples_source=10,
+        n_samples_target=20,
+        shift='concept_drift',
+        noise=0.1,
+        random_state=42,
+        return_dataset=True,
+    )
+    X_train, y_train, sample_domain = dataset.pack_train(
+        as_sources=['s'],
+        as_targets=['t']
+    )
+
+    output = {}
+
+    class FakeTransformer(BaseEstimator):
+
+        def fit(self, X, y=None):
+            output['n_samples'] = X.shape[0]
+            self.fitted_ = True
+
+        def transform(self, X):
+            return X
+
+    pipe = make_da_pipeline(FakeTransformer())
+    pipe.fit(X=X_train, y=y_train, sample_domain=sample_domain)
+
+    assert output['n_samples'] == X_train.shape[0]
 
 
 def test_base_selector_remove_masked_continuous():


### PR DESCRIPTION
This is an addition to the functionality implemented in #123.

The question here is the following:

```python
pipe = make_da_pipeline(StandardScaler(), SubspaceAlignmentAdapter(), LogisticRegression())
pipe.fit(X=X_train, y=y_train, sample_domain=sample_domain)
```

Assuming `y_train` is properly masked. Now
* `SubspaceAlignmentAdapter` gets everything because it declares `sample_domain` in the routing.
* `LogisticRegression` gets only sources (can't work with `sample_domain`)
* `StandardScaler` ??? 

This PR makes it so `StandardScaler` gets both sources **and** targets, as `fit` does not require labels. It previously worked this way, and it seems like this is a much stronger default. For non default behavior, we still can wrap the transformer into a proper selector when those are ready (see #116).

Let me know WDYT.