### PR TITLE
[MRG] Fix tests random seed and TarS

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,11 @@ from skada.datasets import DomainAwareDataset, make_shifted_blobs, make_shifted_
 import pytest
 
 
+@pytest.fixture(scope='function', autouse=True)
+def set_seed():
+    np.random.seed(0)
+
+
 @pytest.fixture(scope='session')
 def da_reg_dataset():
     X, y, sample_domain = make_shifted_datasets(

--- a/skada/_reweight.py
+++ b/skada/_reweight.py
@@ -996,11 +996,12 @@ class MMDTarSReweightAdapter(BaseAdapter):
 
         # compute R
         if discrete:
-            classes = np.unique(y_source)
+            self.classes_ = classes = np.unique(y_source)
             R = np.zeros((X_target.shape[0], len(classes)))
             for i, c in enumerate(classes):
                 R[:, i] = (y_source == c).astype(int)
         else:
+            self.classes_ = None
             R = L @ np.linalg.inv(L + self.reg * np.eye(m))
 
         # compute M
@@ -1108,7 +1109,7 @@ class MMDTarSReweightAdapter(BaseAdapter):
                     X, y, sample_domain = check_X_y_domain(X, y, sample_domain)
                     source_idx = extract_source_indices(sample_domain)
                     y_source = y[source_idx]
-                    classes = np.unique(y_source)
+                    classes = self.classes_
                     R = np.zeros((source_idx.sum(), len(classes)))
                     for i, c in enumerate(classes):
                         R[:, i] = (y_source == c).astype(int)

--- a/skada/tests/test_reweight.py
+++ b/skada/tests/test_reweight.py
@@ -155,6 +155,24 @@ def _base_test_new_X_adapt(estimator, da_dataset):
     res2["sample_weight"] = res2["sample_weight"] / np.sum(res2["sample_weight"])
     assert np.allclose(true_weights, res2["sample_weight"])
 
+    # Check it adapts even if target classes are not present in the new X
+    classes = np.unique(y_train)[::2]
+    mask = np.isin(y_train, classes)
+    X_train = X_train[mask]
+    y_train = y_train[mask]
+    sample_domain = sample_domain[mask]
+    res3 = estimator.adapt(
+        X_train,
+        y_train,
+        sample_domain=sample_domain
+    )
+
+    # Check that the normalized weights are the same
+    true_weights = res1["sample_weight"][mask]
+    true_weights = true_weights / np.sum(true_weights)
+    res3["sample_weight"] = res3["sample_weight"] / np.sum(res3["sample_weight"])
+    assert np.allclose(true_weights, res3["sample_weight"])
+
 
 @pytest.mark.parametrize(
     "estimator",

--- a/skada/tests/test_reweight.py
+++ b/skada/tests/test_reweight.py
@@ -155,7 +155,7 @@ def _base_test_new_X_adapt(estimator, da_dataset):
     res2["sample_weight"] = res2["sample_weight"] / np.sum(res2["sample_weight"])
     assert np.allclose(true_weights, res2["sample_weight"])
 
-    # Check it adapts even if target classes are not present in the new X
+    # Check it adapts even if some target classes are not present in the new X
     classes = np.unique(y_train)[::2]
     mask = np.isin(y_train, classes)
     X_train = X_train[mask]


### PR DESCRIPTION
This PR fixes the `numpy` random seed in every tests.
It also fixes the TarS method when only a subset of classes are present in the target domain.