### PR TITLE
[MRG] Add predict_proba for jdot

### DIFF
--- a/skada/_ot.py
+++ b/skada/_ot.py
@@ -728,7 +728,17 @@ class JDOTClassifier(DAEstimator):
             )
         return self.estimator_.predict(X)
 
-    def score(self, X, y, sample_domain=None, *, sample_weight=None):
+    def predict_proba(self, X, sample_domain=None, *, sample_weight=None):
+        """Predict using the model"""
+        check_is_fitted(self)
+        if sample_domain is not None and np.any(sample_domain >= 0):
+            warnings.warn(
+                "Source domain detected. Predictor is trained on target"
+                "and prediction might be biased."
+            )
+        return self.estimator_.predict_proba(X)
+
+    def score(self, X, y, sample_domain=None, *, sample_weight=None, **kwargs):
         """Return the scores of the prediction"""
         check_is_fitted(self)
         if sample_domain is not None and np.any(sample_domain >= 0):

--- a/skada/_ot.py
+++ b/skada/_ot.py
@@ -730,7 +730,7 @@ class JDOTClassifier(DAEstimator):
         return self.estimator_.predict(X)
 
     def _check_proba(self):
-        if hasattr(self.base_estimator "predict_proba"):
+        if hasattr(self.base_estimator, "predict_proba"):
             return True
         else:
             raise AttributeError(

--- a/skada/_ot.py
+++ b/skada/_ot.py
@@ -730,7 +730,7 @@ class JDOTClassifier(DAEstimator):
         return self.estimator_.predict(X)
 
     def _check_proba(self):
-        if hasattr(self.estimator_, "predict_proba"):
+        if hasattr(self.base_estimator "predict_proba"):
             return True
         else:
             raise AttributeError(

--- a/skada/_ot.py
+++ b/skada/_ot.py
@@ -10,6 +10,7 @@ import ot
 from sklearn.base import clone
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.preprocessing import OneHotEncoder
+from sklearn.utils.metaestimators import available_if
 from sklearn.utils.validation import check_is_fitted
 
 from .base import DAEstimator
@@ -728,6 +729,15 @@ class JDOTClassifier(DAEstimator):
             )
         return self.estimator_.predict(X)
 
+    def _check_proba(self):
+        if hasattr(self.estimator_, "predict_proba"):
+            return True
+        else:
+            raise AttributeError(
+                "The base estimator does not have a predict_proba method"
+            )
+
+    @available_if(_check_proba)
     def predict_proba(self, X, sample_domain=None, *, sample_weight=None):
         """Predict using the model"""
         check_is_fitted(self)

--- a/skada/tests/test_ot.py
+++ b/skada/tests/test_ot.py
@@ -93,6 +93,12 @@ def test_JDOTClassifier(da_multiclass_dataset, da_binary_dataset):
         jdot = JDOTClassifier()
         jdot.fit(X, y, sample_domain=sample_domain)
 
+        # No predict_proba method in base estimator
+        with np.testing.assert_raises(AttributeError):
+            jdot = JDOTClassifier(base_estimator=SVC(probability=False), metric="hinge")
+            jdot.fit(X, y, sample_domain=sample_domain)
+            _ = jdot.predict_proba(X)
+
         # with scorer needing predict_proba
         scorer = PredictionEntropyScorer()
         jdot = JDOTClassifier(base_estimator=SVC(probability=True))

--- a/skada/tests/test_ot.py
+++ b/skada/tests/test_ot.py
@@ -10,6 +10,7 @@ from sklearn.svm import SVC
 
 from skada import JDOTClassifier, JDOTRegressor, make_da_pipeline
 from skada._ot import get_jdot_class_cost_matrix, get_tgt_loss_jdot_class
+from skada.metrics import PredictionEntropyScorer
 from skada.utils import source_target_split
 
 
@@ -91,6 +92,12 @@ def test_JDOTClassifier(da_multiclass_dataset, da_binary_dataset):
         # JDOT with default base estimator
         jdot = JDOTClassifier()
         jdot.fit(X, y, sample_domain=sample_domain)
+
+        # with scorer needing predict_proba
+        scorer = PredictionEntropyScorer()
+        jdot = JDOTClassifier(base_estimator=SVC(probability=True))
+        jdot.fit(X, y, sample_domain=sample_domain)
+        scorer._score(jdot, X, y, sample_domain=sample_domain)
 
         # test raise error
         with np.testing.assert_raises(ValueError):


### PR DESCRIPTION
Fixes #150 

Some scorers need the estimator to have a `predict_proba` function.
Now its the case with jdot