### PR TITLE
[MRG] CircularValidation: Re-encode y labels before training the estimator on y_source_pred

### DIFF
--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -14,7 +14,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import balanced_accuracy_score, check_scoring, log_loss
 from sklearn.model_selection import train_test_split
 from sklearn.neighbors import KernelDensity
-from sklearn.preprocessing import Normalizer
+from sklearn.preprocessing import LabelEncoder, Normalizer
 from sklearn.utils import check_random_state
 from sklearn.utils.extmath import softmax
 from sklearn.utils.metadata_routing import _MetadataRequester, get_routing_for_object
@@ -486,6 +486,14 @@ class CircularValidation(_BaseDomainAwareScorer):
                 y[source_idx], np.ones_like(y[source_idx]) * y_pred_target[0]
             )
         else:
+            # We need to re-encode the target labels
+            # since some estimator like XGBoost
+            # only supports labels in [0, num_classes-1]
+            # and y_pred_target may not be in this range
+            le = LabelEncoder()
+            le.fit(y_pred_target)
+            y_pred_target = le.transform(y_pred_target)
+
             backward_sample_domain = -sample_domain
 
             backward_y = np.zeros_like(y)
@@ -500,6 +508,10 @@ class CircularValidation(_BaseDomainAwareScorer):
             backward_estimator.fit(X, backward_y, sample_domain=backward_sample_domain)
             y_pred_source = backward_estimator.predict(X[source_idx])
 
+            # We go back to the original labels
+            y_pred_source = le.inverse_transform(y_pred_source)
+
+            # We can now compute the score
             score = self.source_scorer(y[source_idx], y_pred_source)
 
         return self._sign * score


### PR DESCRIPTION
With the `CircularValidation` scorer we fit an estimator on the prediction of X_source i.e y_pred_source.
However some estimator only supports labels in [0, num_classes-1], which is not guaranteed.
Indeed for some iterations, `ValueError` were raised:
`ValueError: Invalid classes inferred from unique values of 'y'.  Expected: [0 1 2 3 4 5 6], got [1 2 3 4 7 8 9]
`
**Solution:**
Re-encode the labels before feeding them to the estimator.