### PR TITLE
[MRG] Add predict_proba to DA_SVM

### DIFF
--- a/skada/_self_labeling.py
+++ b/skada/_self_labeling.py
@@ -8,6 +8,7 @@ The DASVM method comes from [11].
         IEEE transactions on pattern analysis and machine intelligence, (2009).
 """
 # Author: Ruben Bueno <ruben.bueno@polytechnique.edu>
+#         Yanis Lalou <yanis.lalou@polytechnique.edu>
 #
 # License: BSD 3-Clause
 
@@ -16,6 +17,8 @@ import math
 import numpy as np
 from sklearn.base import clone
 from sklearn.svm import SVC
+from sklearn.utils.metaestimators import available_if
+from sklearn.utils.validation import check_is_fitted
 
 from skada.utils import check_X_y_domain, source_target_split
 
@@ -60,7 +63,7 @@ class DASVMClassifier(DAEstimator):
     ):
         super().__init__()
         if base_estimator is None:
-            self.base_estimator = SVC()
+            self.base_estimator = SVC(probability=True)
         else:
             self.base_estimator = base_estimator
         self.max_iter = max_iter
@@ -260,6 +263,22 @@ class DASVMClassifier(DAEstimator):
         `predict` method from the estimator we fitted
         """
         return self.base_estimator_.predict(X)
+
+    def _check_proba(self):
+        if hasattr(self.base_estimator, "predict_proba"):
+            return True
+        else:
+            raise AttributeError(
+                "The base estimator does not have a predict_proba method"
+            )
+
+    @available_if(_check_proba)
+    def predict_proba(self, X):
+        """Return predicted probabilities by the fitted estimator for `X`
+        `predict_proba` method from the estimator we fitted
+        """
+        check_is_fitted(self)
+        return self.base_estimator.predict_proba(X)
 
     def decision_function(self, X):
         """Return values of the decision function of the

--- a/skada/tests/test_self_labeling.py
+++ b/skada/tests/test_self_labeling.py
@@ -1,12 +1,17 @@
 # Author: Ruben Bueno <ruben.bueno@polytechnique.edu>
+#         Yanis Lalou <yanis.lalou@polytechnique.edu>
+#
+# License: BSD 3-Clause
 
+import numpy as np
 import pytest
 from sklearn.preprocessing import StandardScaler
+from sklearn.svm import SVC
 
 from skada._pipeline import make_da_pipeline
 from skada._self_labeling import DASVMClassifier
 from skada.datasets import make_shifted_datasets
-from skada.utils import check_X_y_domain, source_target_split
+from skada.utils import check_X_y_domain
 
 
 @pytest.mark.parametrize(
@@ -22,7 +27,6 @@ def test_dasvm_estimator(label, n, m):
         label=label,
     )
     X, y, sample_domain = check_X_y_domain(X, y, sample_domain)
-    Xs, Xt, ys, yt = source_target_split(X, y, sample_domain=sample_domain)
 
     clf_dasvm = DASVMClassifier(k=3, save_estimators=True, save_indices=True).fit(
         X, y, sample_domain=sample_domain
@@ -46,3 +50,32 @@ def test_dasvm_estimator(label, n, m):
         manage_pipeline = True
     finally:
         assert manage_pipeline, "Couldn't use make_da_pipeline with DASVMClassifier"
+
+
+def test_dasvm_estimator_predict_proba():
+    X, y, sample_domain = make_shifted_datasets(
+        n_samples_source=5,
+        n_samples_target=5,
+        shift="covariate_shift",
+        noise=None,
+        label="binary",
+    )
+    X, y, sample_domain = check_X_y_domain(X, y, sample_domain)
+
+    # Test with a base estimator that does support predict_proba
+    clf_dasvm = DASVMClassifier(k=3, base_estimator=SVC(probability=True)).fit(
+        X, y, sample_domain=sample_domain
+    )
+
+    assert (
+        clf_dasvm.predict_proba(X).shape[0] == y.shape[0]
+        and clf_dasvm.predict_proba(X).shape[1] == np.unique(y).shape[0]
+    ), "Wrong length of the predicted probabilities when using `predict_proba` method"
+
+    # Test with a base estimator that does not support predict_proba
+    clf_dasvm = DASVMClassifier(k=3, base_estimator=SVC(probability=False)).fit(
+        X, y, sample_domain=sample_domain
+    )
+
+    with pytest.raises(AttributeError):
+        clf_dasvm.predict_proba(X)


### PR DESCRIPTION
A lot of skada scorers need the estimator to have the `predict_proba` method.
So here we implement it depending on if the `base_estimator` has it or not.