### PR TITLE
Custom_loss_function

### DIFF
--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -462,7 +462,7 @@ class DeepEmbeddedValidation(_BaseDomainAwareScorer):
         """
         Compute loss between true labels and predicted probability estimates or scores.
         
-        The loss function can be either cross-entropy loss or binary cross-entropy loss (BCELoss).
+        The loss function can be either cross-entropy loss or binary cross-entropy loss
         
         Parameters
         ----------


### PR DESCRIPTION
Changed metrics.py to add a new parameter 'criterion' within 'loss_function' with default as 'cross_entropy_loss' and can switch to 'BCELoss'