### PR TITLE
Fix SelectSource selector

### DIFF
--- a/skada/base.py
+++ b/skada/base.py
@@ -329,7 +329,7 @@ class BaseSelector(BaseEstimator, _DAMetadataRequesterMixin):
     def score(self, X, y, **params):
         return self._route_to_estimator('score', X, y=y, **params)
 
-    def _unwrap_from_container(self, X_container, params):
+    def _unwrap_from_container(self, X_container, params, y=None):
         if isinstance(X_container, AdaptationOutput):
             X_out = X_container.X
             for k, v in X_container.items():
@@ -338,10 +338,17 @@ class BaseSelector(BaseEstimator, _DAMetadataRequesterMixin):
         else:
             X_out = X_container
 
-        X_out, sample_domain = check_X_domain(
-            X_out,
-            sample_domain=params.get('sample_domain')
-        )
+        if y is not None:
+            X_out, y, sample_domain = check_X_y_domain(
+                X_out,
+                y,
+                sample_domain=params.get('sample_domain')
+            )
+        else:
+            X_out, sample_domain = check_X_domain(
+                X_out,
+                sample_domain=params.get('sample_domain')
+            )
         params['sample_domain'] = sample_domain
 
         return X_out, params
@@ -550,7 +557,7 @@ class _BaseSelectDomain(Shared):
         """
 
     def fit(self, X_container, y, **params):
-        X_input, params = self._unwrap_from_container(X_container, params)
+        X_input, params = self._unwrap_from_container(X_container, params, y)
         filter_masks = self._select_indices(params['sample_domain'])
         X_input, y, params = _apply_domain_masks(X_input, y, params, masks=filter_masks)
         return super().fit(X_input, y, **params)

--- a/skada/utils.py
+++ b/skada/utils.py
@@ -19,6 +19,7 @@ from skada._utils import (
     _DEFAULT_TARGET_DOMAIN_LABEL,
     _DEFAULT_TARGET_DOMAIN_ONLY_LABEL,
     _check_y_masking,
+    Y_Type,
 )
 
 
@@ -81,7 +82,7 @@ def check_X_y_domain(
         # labels masked with -1 (for classification) are recognized as targets,
         # labels masked with nan (for regression) are recognized as targets,
         # the rest is treated as a source
-        if y_type == 'classification':
+        if y_type == Y_Type.DISCRETE:
             mask = (y == _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL)
         else:
             mask = (np.isnan(y))
@@ -436,7 +437,7 @@ def source_target_merge(
             pair_index = i+1 if index_is_empty == i else i
 
             y_type = type_of_target(arrays[pair_index])
-            if y_type == 'binary' or y_type == 'multiclass':
+            if y_type == Y_Type.DISCRETE:
                 default_masked_label = _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL
             else:
                 default_masked_label = _DEFAULT_MASKED_TARGET_REGRESSION_LABEL


### PR DESCRIPTION
**Issue:** SelectSource is raising the following issue when wrapping estimators: `ValueError: Found array with 0 sample(s) (shape=(0, 2)) while a minimum of 1 is required.`

- Add y arg to BaseSelector._unwrap_from_container()
- Bug fix check_X_y_domain() + source_target_merge()