### PR TITLE
Allow multi dim inputs through the pipeline

### DIFF
--- a/skada/base.py
+++ b/skada/base.py
@@ -340,7 +340,8 @@ class BaseSelector(BaseEstimator, _DAMetadataRequesterMixin):
 
         X_out, sample_domain = check_X_domain(
             X_out,
-            sample_domain=params.get('sample_domain')
+            sample_domain=params.get('sample_domain'),
+            allow_nd=True,
         )
         params['sample_domain'] = sample_domain
 

--- a/skada/tests/test_self_labeling.py
+++ b/skada/tests/test_self_labeling.py
@@ -66,6 +66,7 @@ def test_dasvm_estimator_predict_proba():
         shift="covariate_shift",
         noise=None,
         label="binary",
+        random_state=0,
     )
     X, y, sample_domain = check_X_y_domain(X, y, sample_domain)
 

--- a/skada/utils.py
+++ b/skada/utils.py
@@ -122,6 +122,7 @@ def check_X_domain(
     allow_target: bool = True,
     allow_multi_target: bool = True,
     allow_auto_sample_domain: bool = True,
+    allow_nd: bool = False,
 ):
     """
     Input validation for domain adaptation (DA) estimator.
@@ -146,6 +147,8 @@ def check_X_domain(
         Allow multiple target domains.
     allow_auto_sample_domain : bool, optional (default=True)
         Allow automatic generation of sample_domain if not provided.
+    allow_nd : bool, optional (default=False)
+        Allow X and y to be N-dimensional arrays.
 
     Returns
     -------
@@ -154,7 +157,7 @@ def check_X_domain(
     sample_domain : array
         Combined domain labels for source and target domains.
     """
-    X = check_array(X, input_name='X')
+    X = check_array(X, input_name='X', allow_nd=allow_nd)
 
     if sample_domain is None and not allow_auto_sample_domain:
         raise ValueError("Either 'sample_domain' or 'allow_auto_sample_domain' "


### PR DESCRIPTION
Code sample from the Slack conversation:

```python
# %%
from pyriemann.estimation import Covariances
from pyriemann.tangentspace import TangentSpace
from skada import make_da_pipeline
from skada import CORALAdapter
import numpy as np
from skada.datasets import DomainAwareDataset
# %%
pipe = make_da_pipeline(
    Covariances(estimator='oas'),
    TangentSpace(),
    CORALAdapter()
)
# %%
Xs = np.random.randn(100, 22, 30)
Xt = np.random.randn(100, 22, 30)
ys = np.random.randint(0, 2, 100)
yt = np.random.randint(0, 2, 100)

# %%
dataset = DomainAwareDataset()
dataset.add_domain(Xs, ys, 'source')
dataset.add_domain(Xt, yt, 'target')
# %%
X, y, sample_domain = dataset.pack_train(as_sources=["source"], as_targets=["target"])
# %%
pipe.fit(X, y, sample_domain=sample_domain)
```