### PR TITLE
Fix CDAN input to domain_classifier and gpu compatibility

### DIFF
--- a/skada/deep/_adversarial.py
+++ b/skada/deep/_adversarial.py
@@ -241,7 +241,7 @@ class CDANModule(DomainAwareModule):
 
     def forward(self, X, sample_domain=None, is_fit=False, return_features=False):
         if is_fit:
-            source_idx = (sample_domain >= 0)
+            source_idx = sample_domain >= 0
 
             X_t = X[~source_idx]
             X_s = X[source_idx]
@@ -282,23 +282,18 @@ class CDANModule(DomainAwareModule):
 
             domain_pred_s = self.domain_classifier_(multilinear_map)
             domain_pred_t = self.domain_classifier_(multilinear_map_target)
-            domain_pred = torch.empty(
-                len(sample_domain),
-                device=domain_pred_s.device
-            )
+            domain_pred = torch.empty(len(sample_domain), device=domain_pred_s.device)
             domain_pred[source_idx] = domain_pred_s
             domain_pred[~source_idx] = domain_pred_t
 
             y_pred = torch.empty(
-                (len(sample_domain), y_pred_s.shape[1]),
-                device=y_pred_s.device
+                (len(sample_domain), y_pred_s.shape[1]), device=y_pred_s.device
             )
             y_pred[source_idx] = y_pred_s
             y_pred[~source_idx] = y_pred_t
 
             features = torch.empty(
-                (len(sample_domain), features_s.shape[1]),
-                device=features_s.device
+                (len(sample_domain), features_s.shape[1]), device=features_s.device
             )
             features[source_idx] = features_s
             features[~source_idx] = features_t
@@ -350,9 +345,7 @@ def CDAN(
         A PyTorch :class:`~torch.nn.Module` used to classify the
         domain. If None, a domain classifier is created following [1]_.
     num_features : int, default=None
-        Size of the input of domain classifier,
-        e.g size of the last layer of
-        the feature extractor.
+        Size of the embedding space e.g. the size of the output of layer_name.
         If domain_classifier is None, num_features has to be
         provided.
     n_classes : int, default None
@@ -373,9 +366,7 @@ def CDAN(
                 "If domain_classifier is None, num_features has to be provided"
             )
         if n_classes is None:
-            raise ValueError(
-                "If n_classes is None, n_classes has to be provided"
-            )
+            raise ValueError("If n_classes is None, n_classes has to be provided")
         num_features = np.min([num_features * n_classes, max_features])
         domain_classifier = DomainClassifier(num_features=num_features)
 

--- a/skada/deep/_adversarial.py
+++ b/skada/deep/_adversarial.py
@@ -350,7 +350,7 @@ def CDAN(
         provided.
     n_classes : int, default None
         Number of output classes.
-        If domain classifier is None, n_classes has to be provided.
+        If domain_classifier is None, n_classes has to be provided.
     domain_criterion : torch criterion (class)
         The criterion (loss) used to compute the
         CDAN loss. If None, a BCELoss is used.

--- a/skada/deep/_adversarial.py
+++ b/skada/deep/_adversarial.py
@@ -366,7 +366,9 @@ def CDAN(
                 "If domain_classifier is None, num_features has to be provided"
             )
         if n_classes is None:
-            raise ValueError("If n_classes is None, n_classes has to be provided")
+            raise ValueError(
+                "If domain_classifier is None, n_classes has to be provided"
+            )
         num_features = np.min([num_features * n_classes, max_features])
         domain_classifier = DomainClassifier(num_features=num_features)
 

--- a/skada/deep/base.py
+++ b/skada/deep/base.py
@@ -281,14 +281,14 @@ class DomainAwareModule(torch.nn.Module):
 
             y_pred = torch.empty(
                 (len(sample_domain), y_pred_s.shape[1]),
-                device = y_pred_s.device
+                device=y_pred_s.device
             )
             y_pred[source_idx] = y_pred_s
             y_pred[~source_idx] = y_pred_t
 
             features = torch.empty(
                 (len(sample_domain), features_s.shape[1]),
-                device = features_s.device
+                device=features_s.device
             )
             features[source_idx] = features_s
             features[~source_idx] = features_t

--- a/skada/deep/base.py
+++ b/skada/deep/base.py
@@ -14,8 +14,6 @@ from skorch import NeuralNetClassifier
 
 from .utils import _register_forwards_hook
 
-from skada.utils import extract_source_indices
-
 from skada.base import _DAMetadataRequesterMixin
 
 

--- a/skada/deep/tests/test_deep_adversarial.py
+++ b/skada/deep/tests/test_deep_adversarial.py
@@ -63,16 +63,22 @@ def test_dann(domain_classifier, domain_criterion, num_features):
 
 
 @pytest.mark.parametrize(
-    "domain_classifier, domain_criterion, num_feature, max_feature",
+    "domain_classifier, domain_criterion, num_feature, max_feature, n_classes",
     [
-        (DomainClassifier(num_features=20), BCELoss(), None, 4096),
-        (DomainClassifier(num_features=20), None, None, 4096),
-        (None, None, 20, 4096),
-        (None, BCELoss(), 20, 4096),
-        (None, BCELoss(), 20, 10),
+        (DomainClassifier(num_features=20), BCELoss(), None, 4096, 2),
+        (DomainClassifier(num_features=20), None, None, 4096, 2),
+        (None, None, 20, 4096, 2),
+        (None, BCELoss(), 20, 4096, 2),
+        (None, BCELoss(), 20, 10, 2),
     ],
 )
-def test_cdan(domain_classifier, domain_criterion, num_feature, max_feature):
+def test_cdan(
+    domain_classifier,
+    domain_criterion,
+    num_feature,
+    max_feature,
+    n_classes
+):
     module = ToyModule2D()
     module.eval()
 
@@ -91,6 +97,7 @@ def test_cdan(domain_classifier, domain_criterion, num_feature, max_feature):
         reg=1,
         domain_classifier=domain_classifier,
         num_features=num_feature,
+        n_classes=n_classes,
         domain_criterion=domain_criterion,
         max_features=max_feature,
         layer_name="dropout",
@@ -141,6 +148,22 @@ def test_missing_num_features():
         )
 
 
+def test_missing_n_classes():
+    with pytest.raises(ValueError):
+        CDAN(
+            ToyModule2D(),
+            reg=1,
+            domain_classifier=None,
+            num_features=10,
+            n_classes=None,
+            domain_criterion=BCELoss(),
+            layer_name="dropout",
+            batch_size=10,
+            max_epochs=10,
+            train_split=None,
+        )
+
+
 def test_return_features():
     num_features = 10
     n_classes = 2
@@ -161,7 +184,8 @@ def test_return_features():
         ToyModule2D(),
         reg=1,
         domain_classifier=None,
-        num_features=num_features * n_classes,
+        num_features=num_features,
+        n_classes=n_classes,
         domain_criterion=BCELoss(),
         layer_name="dropout",
         batch_size=10,

--- a/skada/deep/tests/test_deep_adversarial.py
+++ b/skada/deep/tests/test_deep_adversarial.py
@@ -72,13 +72,7 @@ def test_dann(domain_classifier, domain_criterion, num_features):
         (None, BCELoss(), 10, 10, 2),
     ],
 )
-def test_cdan(
-    domain_classifier,
-    domain_criterion,
-    num_feature,
-    max_feature,
-    n_classes
-):
+def test_cdan(domain_classifier, domain_criterion, num_feature, max_feature, n_classes):
     module = ToyModule2D()
     module.eval()
 

--- a/skada/deep/tests/test_deep_adversarial.py
+++ b/skada/deep/tests/test_deep_adversarial.py
@@ -67,9 +67,9 @@ def test_dann(domain_classifier, domain_criterion, num_features):
     [
         (DomainClassifier(num_features=20), BCELoss(), None, 4096, 2),
         (DomainClassifier(num_features=20), None, None, 4096, 2),
-        (None, None, 20, 4096, 2),
-        (None, BCELoss(), 20, 4096, 2),
-        (None, BCELoss(), 20, 10, 2),
+        (None, None, 10, 4096, 2),
+        (None, BCELoss(), 10, 4096, 2),
+        (None, BCELoss(), 10, 10, 2),
     ],
 )
 def test_cdan(


### PR DESCRIPTION
The input size of domain_classifier is n_classes * n_features, so I propose to add n_classes as argument of CDAN to create domain_classifier with the right input size when it's not provided.