### PR TITLE
[MRG] MMDLS handle case where we have X_source and no y_source

### DIFF
--- a/skada/_mapping.py
+++ b/skada/_mapping.py
@@ -889,7 +889,7 @@ class MMDLSConSMappingAdapter(BaseAdapter):
             if np.array_equal(self.X_source_, X[source_idx]):
                 W, B = self.W_, self.B_
             else:
-                if self.discrete_:
+                if self.discrete_ and y is not None:
                     # recompute the mapping
                     X, sample_domain = check_X_domain(X, sample_domain)
                     source_idx = extract_source_indices(sample_domain)

--- a/skada/tests/test_mapping.py
+++ b/skada/tests/test_mapping.py
@@ -234,3 +234,51 @@ def test_reg_new_X_adapt(estimator):
         return_dataset=True,
     )
     _base_test_new_X_adapt(estimator, dataset)
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        OTMapping(),
+        EntropicOTMapping(),
+        ClassRegularizerOTMapping(),
+        ClassRegularizerOTMapping(norm="l1l2"),
+        LinearOTMapping(),
+        CORAL(),
+        pytest.param(
+            MMDLSConSMapping(),
+            marks=pytest.mark.skipif(not torch, reason="PyTorch not installed"),
+        ),
+    ],
+)
+def test_mapping_source_samples(estimator, da_blobs_dataset):
+    X, y, sample_domain = da_blobs_dataset
+    X_source, X_target, y_source, y_target = source_target_split(
+        X, y, sample_domain=sample_domain
+    )
+
+    # Just scale some feature to avoid having an identity cov matrix
+    X_scaled = np.copy(X_source)
+    X_target_scaled = np.copy(X_target)
+    X_scaled[:, 0] *= 2
+    X_target_scaled[:, 1] *= 3
+    dataset = DomainAwareDataset(
+        [
+            (X_scaled, y_source, "s"),
+            (X_target_scaled, y_target, "t"),
+        ]
+    )
+
+    X_train, y_train, sample_domain = dataset.pack_train(
+        as_sources=["s"], as_targets=["t"]
+    )
+    estimator.fit(X_train, y_train, sample_domain=sample_domain)
+
+    # Adapt with new X, i.e. same domain, different samples
+    rng = check_random_state(42)
+    idx = rng.choice(len(X_train), len(X_train) // 5, replace=False)
+
+    y_pred = estimator.predict(
+        X_train[idx], sample_domain=sample_domain[idx], allow_source=True
+    )
+    assert y_pred.shape[0] == len(idx)


### PR DESCRIPTION
Before when using the DeepValidation scorer we had this error:

```Traceback (most recent call last):
  File "/Users/yanislalou/Documents/CMAP/skada_test_venv/lib/python3.9/site-packages/sklearn/metrics/_scorer.py", line 141, in __call__
    score = scorer(estimator, *args, **routed_params.get(name).score)
  File "/Users/yanislalou/Documents/CMAP/skada_test_venv/lib/python3.9/site-packages/skada/metrics.py", line 43, in __call__
    return self._score(estimator, X, y, sample_domain=sample_domain, **params)
  File "/Users/yanislalou/Documents/CMAP/skada_test_venv/lib/python3.9/site-packages/skada/metrics.py", line 433, in _score
    y_pred = estimator.predict_proba(
  File "/Users/yanislalou/Documents/CMAP/skada_test_venv/lib/python3.9/site-packages/sklearn/pipeline.py", line 728, in predict_proba
    Xt = transform.transform(Xt, **routed_params[name].transform)
  File "/Users/yanislalou/Documents/CMAP/skada_test_venv/lib/python3.9/site-packages/skada/base.py", line 288, in transform
    return self._route_to_estimator('transform', X, **params)
  File "/Users/yanislalou/Documents/CMAP/skada_test_venv/lib/python3.9/site-packages/skada/base.py", line 425, in _route_to_estimator
    output = method(X, **routed_params) if y is None else method(
  File "/Users/yanislalou/Documents/CMAP/skada_test_venv/lib/python3.9/site-packages/skada/_mapping.py", line 896, in transform
    y_source = y[source_idx]
TypeError: 'NoneType' object is not subscriptable
```
