### PR TITLE
Fix density reweight

### DIFF
--- a/skada/_reweight.py
+++ b/skada/_reweight.py
@@ -133,7 +133,10 @@ class DensityReweightAdapter(BaseReweightAdapter):
         ws = self.weight_estimator_source_.score_samples(X[source_idx])
         wt = self.weight_estimator_target_.score_samples(X[source_idx])
         source_weights = np.exp(wt - ws)
-        source_weights /= source_weights.mean()
+
+        if source_weights.mean() != 0:
+            source_weights /= source_weights.mean()
+
         weights = np.zeros(X.shape[0], dtype=source_weights.dtype)
         weights[source_idx] = source_weights
         return weights

--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -351,10 +351,7 @@ class DeepEmbeddedValidation(_BaseDomainAwareScorer):
 
     def _no_reduc_log_loss(self, y, y_pred):
         return np.array(
-            [
-                self.cross_entropy_loss(y[i : i + 1], y_pred[i : i + 1])
-                for i in range(len(y))
-            ]
+            [self.cross_entropy_loss(y[i], y_pred[i]) for i in range(len(y))]
         )
 
     def _fit_adapt(self, features, features_target):
@@ -462,7 +459,7 @@ class DeepEmbeddedValidation(_BaseDomainAwareScorer):
         -------
         - Cross-entropy loss.
         """
-        num_classes = y_pred.shape[1]
+        num_classes = y_pred.shape[0]
 
         # Convert integer labels to one-hot encoding
         y_true_one_hot = np.eye(num_classes)[y_true]


### PR DESCRIPTION
Now when `source_weights.mean() == 0` we don't divide `source_weights` by it.