### PR TITLE
FIX test collection don't run examples

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ test = pytest
 # disable-pytest-warnings should be removed once we rewrite tests
 # using yield with parametrize
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
-testpaths = sklearn
+testpaths = skada
 addopts =
     --doctest-modules
     --disable-pytest-warnings


### PR DESCRIPTION
On a fresh system, running `pytest --collect-only` will run the examples. This is typically done by the pytest extension of VSCode, which is annoying.
This fixes the test collection.