### PR TITLE
[WIP] Center data when using transform of coral

### DIFF
--- a/skada/_mapping.py
+++ b/skada/_mapping.py
@@ -571,6 +571,8 @@ class CORALAdapter(BaseAdapter):
           - None: no shrinkage).
           - 'auto': automatic shrinkage using the Ledoit-Wolf lemma.
           - float between 0 and 1: fixed shrinkage parameter.
+    assume_centered: bool, default=True
+        If True, data are not centered before computation.
 
     Attributes
     ----------
@@ -586,9 +588,10 @@ class CORALAdapter(BaseAdapter):
            In Advances in Computer Vision and Pattern Recognition, 2017.
     """
 
-    def __init__(self, reg="auto"):
+    def __init__(self, reg="auto", assume_centered=True):
         super().__init__()
         self.reg = reg
+        self.assume_centered = assume_centered
 
     def fit(self, X, y=None, sample_domain=None):
         """Fit adaptation parameters.
@@ -612,8 +615,16 @@ class CORALAdapter(BaseAdapter):
         )
         X_source, X_target = source_target_split(X, sample_domain=sample_domain)
 
-        cov_source_ = _estimate_covariance(X_source, shrinkage=self.reg)
-        cov_target_ = _estimate_covariance(X_target, shrinkage=self.reg)
+        cov_source_ = _estimate_covariance(
+            X_source,
+            shrinkage=self.reg,
+            assume_centered=self.assume_centered
+        )
+        cov_target_ = _estimate_covariance(
+            X_target,
+            shrinkage=self.reg,
+            assume_centered=self.assume_centered
+        )
         self.cov_source_inv_sqrt_ = _invsqrtm(cov_source_)
         self.cov_target_sqrt_ = _sqrtm(cov_target_)
         return self
@@ -648,15 +659,19 @@ class CORALAdapter(BaseAdapter):
             allow_multi_source=True,
             allow_multi_target=True,
         )
-        X_source, X_target = source_target_split(X, sample_domain=sample_domain)
+        X_source_adapt, X_target_adapt = source_target_split(X, sample_domain=sample_domain)
 
-        if X_source.shape[0] > 0:
-            X_source_adapt = np.dot(X_source, self.cov_source_inv_sqrt_)
+        if X_source_adapt.shape[0] > 0:
+            # Center data
+            if self.assume_centered == False:
+                X_source_adapt = X_source_adapt - X_source_adapt.mean(axis=0)
+
+            # Whitening and coloring source data
+            X_source_adapt = np.dot(X_source_adapt, self.cov_source_inv_sqrt_)
             X_source_adapt = np.dot(X_source_adapt, self.cov_target_sqrt_)
-        else:
-            X_source_adapt = X_source
+
         X_adapt, _ = source_target_merge(
-            X_source_adapt, X_target, sample_domain=sample_domain
+            X_source_adapt, X_target_adapt, sample_domain=sample_domain
         )
         return X_adapt
 
@@ -664,6 +679,7 @@ class CORALAdapter(BaseAdapter):
 def CORAL(
     base_estimator=None,
     reg="auto",
+    assume_centered=True,
 ):
     """CORAL pipeline with adapter and estimator.
 
@@ -680,6 +696,8 @@ def CORAL(
           - None: no shrinkage).
           - 'auto': automatic shrinkage using the Ledoit-Wolf lemma.
           - float between 0 and 1: fixed shrinkage parameter.
+    assume_centered: bool, default=True
+        If True, data are not centered before computation.
 
     Returns
     -------
@@ -696,7 +714,7 @@ def CORAL(
         base_estimator = SVC(kernel="rbf")
 
     return make_da_pipeline(
-        CORALAdapter(reg=reg),
+        CORALAdapter(reg=reg, assume_centered=assume_centered),
         base_estimator,
     )
 

--- a/skada/_mapping.py
+++ b/skada/_mapping.py
@@ -576,8 +576,8 @@ class CORALAdapter(BaseAdapter):
 
     Attributes
     ----------
-    mean_source: array, shape (n_features,)
-    mean_target: array, shape (n_features,)
+    mean_source_: array, shape (n_features,)
+    mean_target_: array, shape (n_features,)
     cov_source_inv_sqrt_: array, shape (n_features, n_features)
         Inverse of the square root of covariance of the source data with regularization.
     cov_target_sqrt_: array, shape (n_features, n_features)
@@ -617,8 +617,8 @@ class CORALAdapter(BaseAdapter):
         )
         X_source, X_target = source_target_split(X, sample_domain=sample_domain)
 
-        self.mean_source = np.mean(X_source, axis=0)
-        self.mean_target = np.mean(X_target, axis=0)
+        self.mean_source_ = np.mean(X_source, axis=0)
+        self.mean_target_ = np.mean(X_target, axis=0)
         cov_source_ = _estimate_covariance(
             X_source, shrinkage=self.reg, assume_centered=self.assume_centered
         )
@@ -667,7 +667,7 @@ class CORALAdapter(BaseAdapter):
         if X_source_adapt.shape[0] > 0:
             # Center data
             if not self.assume_centered:
-                X_source_adapt = X_source_adapt - self.mean_source
+                X_source_adapt = X_source_adapt - self.mean_source_
 
             # Whitening and coloring source data
             X_source_adapt = np.dot(X_source_adapt, self.cov_source_inv_sqrt_)
@@ -675,7 +675,7 @@ class CORALAdapter(BaseAdapter):
 
         # Adapt the target data
         if X_target_adapt.shape[0] > 0 and not self.assume_centered:
-            X_target_adapt = X_target_adapt - self.mean_target
+            X_target_adapt = X_target_adapt - self.mean_target_
 
         X_adapt, _ = source_target_merge(
             X_source_adapt, X_target_adapt, sample_domain=sample_domain

--- a/skada/_mapping.py
+++ b/skada/_mapping.py
@@ -571,7 +571,7 @@ class CORALAdapter(BaseAdapter):
           - None: no shrinkage).
           - 'auto': automatic shrinkage using the Ledoit-Wolf lemma.
           - float between 0 and 1: fixed shrinkage parameter.
-    assume_centered: bool, default=True
+    assume_centered: bool, default=False
         If True, data are not centered before computation.
 
     Attributes
@@ -588,7 +588,7 @@ class CORALAdapter(BaseAdapter):
            In Advances in Computer Vision and Pattern Recognition, 2017.
     """
 
-    def __init__(self, reg="auto", assume_centered=True):
+    def __init__(self, reg="auto", assume_centered=False):
         super().__init__()
         self.reg = reg
         self.assume_centered = assume_centered
@@ -661,14 +661,19 @@ class CORALAdapter(BaseAdapter):
         )
         X_source_adapt, X_target_adapt = source_target_split(X, sample_domain=sample_domain)
 
+        # Adapt the source data
         if X_source_adapt.shape[0] > 0:
             # Center data
-            if self.assume_centered == False:
+            if not self.assume_centered:
                 X_source_adapt = X_source_adapt - X_source_adapt.mean(axis=0)
 
             # Whitening and coloring source data
             X_source_adapt = np.dot(X_source_adapt, self.cov_source_inv_sqrt_)
             X_source_adapt = np.dot(X_source_adapt, self.cov_target_sqrt_)
+
+        # Adapt the target data
+        if X_target_adapt.shape[0] > 0 and not self.assume_centered:
+            X_target_adapt = X_target_adapt - X_target_adapt.mean(axis=0)
 
         X_adapt, _ = source_target_merge(
             X_source_adapt, X_target_adapt, sample_domain=sample_domain
@@ -679,7 +684,7 @@ class CORALAdapter(BaseAdapter):
 def CORAL(
     base_estimator=None,
     reg="auto",
-    assume_centered=True,
+    assume_centered=False,
 ):
     """CORAL pipeline with adapter and estimator.
 
@@ -696,7 +701,7 @@ def CORAL(
           - None: no shrinkage).
           - 'auto': automatic shrinkage using the Ledoit-Wolf lemma.
           - float between 0 and 1: fixed shrinkage parameter.
-    assume_centered: bool, default=True
+    assume_centered: bool, default=False
         If True, data are not centered before computation.
 
     Returns

--- a/skada/_mapping.py
+++ b/skada/_mapping.py
@@ -576,6 +576,8 @@ class CORALAdapter(BaseAdapter):
 
     Attributes
     ----------
+    mean_source: array, shape (n_features,)
+    mean_target: array, shape (n_features,)
     cov_source_inv_sqrt_: array, shape (n_features, n_features)
         Inverse of the square root of covariance of the source data with regularization.
     cov_target_sqrt_: array, shape (n_features, n_features)
@@ -615,6 +617,8 @@ class CORALAdapter(BaseAdapter):
         )
         X_source, X_target = source_target_split(X, sample_domain=sample_domain)
 
+        self.mean_source = np.mean(X_source, axis=0)
+        self.mean_target = np.mean(X_target, axis=0)
         cov_source_ = _estimate_covariance(
             X_source, shrinkage=self.reg, assume_centered=self.assume_centered
         )
@@ -663,7 +667,7 @@ class CORALAdapter(BaseAdapter):
         if X_source_adapt.shape[0] > 0:
             # Center data
             if not self.assume_centered:
-                X_source_adapt = X_source_adapt - X_source_adapt.mean(axis=0)
+                X_source_adapt = X_source_adapt - self.mean_source
 
             # Whitening and coloring source data
             X_source_adapt = np.dot(X_source_adapt, self.cov_source_inv_sqrt_)
@@ -671,7 +675,7 @@ class CORALAdapter(BaseAdapter):
 
         # Adapt the target data
         if X_target_adapt.shape[0] > 0 and not self.assume_centered:
-            X_target_adapt = X_target_adapt - X_target_adapt.mean(axis=0)
+            X_target_adapt = X_target_adapt - self.mean_target
 
         X_adapt, _ = source_target_merge(
             X_source_adapt, X_target_adapt, sample_domain=sample_domain

--- a/skada/_mapping.py
+++ b/skada/_mapping.py
@@ -616,14 +616,10 @@ class CORALAdapter(BaseAdapter):
         X_source, X_target = source_target_split(X, sample_domain=sample_domain)
 
         cov_source_ = _estimate_covariance(
-            X_source,
-            shrinkage=self.reg,
-            assume_centered=self.assume_centered
+            X_source, shrinkage=self.reg, assume_centered=self.assume_centered
         )
         cov_target_ = _estimate_covariance(
-            X_target,
-            shrinkage=self.reg,
-            assume_centered=self.assume_centered
+            X_target, shrinkage=self.reg, assume_centered=self.assume_centered
         )
         self.cov_source_inv_sqrt_ = _invsqrtm(cov_source_)
         self.cov_target_sqrt_ = _sqrtm(cov_target_)
@@ -659,7 +655,9 @@ class CORALAdapter(BaseAdapter):
             allow_multi_source=True,
             allow_multi_target=True,
         )
-        X_source_adapt, X_target_adapt = source_target_split(X, sample_domain=sample_domain)
+        X_source_adapt, X_target_adapt = source_target_split(
+            X, sample_domain=sample_domain
+        )
 
         # Adapt the source data
         if X_source_adapt.shape[0] > 0:

--- a/skada/_utils.py
+++ b/skada/_utils.py
@@ -43,17 +43,20 @@ class Y_Type(Enum):
     DISCRETE = "discrete"
 
 
-def _estimate_covariance(X, shrinkage):
+def _estimate_covariance(X, shrinkage, assume_centered=False):
     if shrinkage is None:
-        s = empirical_covariance(X)
+        s = empirical_covariance(X, assume_centered=assume_centered)
     elif shrinkage == "auto":
-        sc = StandardScaler()  # standardize features
+        sc = StandardScaler(with_mean=not assume_centered)
         X = sc.fit_transform(X)
         s = ledoit_wolf(X)[0]
         # rescale
         s = sc.scale_[:, np.newaxis] * s * sc.scale_[np.newaxis, :]
     elif isinstance(shrinkage, Real):
-        s = shrunk_covariance(empirical_covariance(X), shrinkage)
+        s = shrunk_covariance(
+            empirical_covariance(X, assume_centered=assume_centered),
+            shrinkage=shrinkage
+        )
     return s
 
 

--- a/skada/_utils.py
+++ b/skada/_utils.py
@@ -55,7 +55,7 @@ def _estimate_covariance(X, shrinkage, assume_centered=False):
     elif isinstance(shrinkage, Real):
         s = shrunk_covariance(
             empirical_covariance(X, assume_centered=assume_centered),
-            shrinkage=shrinkage
+            shrinkage=shrinkage,
         )
     return s
 

--- a/skada/tests/test_mapping.py
+++ b/skada/tests/test_mapping.py
@@ -109,7 +109,8 @@ def test_mapping_estimator(estimator, da_blobs_dataset):
         make_da_pipeline(LinearOTMappingAdapter(), Ridge()),
         LinearOTMapping(Ridge()),
         make_da_pipeline(CORALAdapter(), Ridge()),
-        CORAL(Ridge()),
+        CORAL(Ridge(), assume_centered=False),
+        CORAL(Ridge(), assume_centered=True),
         pytest.param(
             make_da_pipeline(MMDLSConSMappingAdapter(gamma=1e-3), Ridge()),
             marks=pytest.mark.skipif(not torch, reason="PyTorch not installed"),
@@ -185,7 +186,7 @@ def _base_test_new_X_adapt(estimator, da_dataset):
         (ClassRegularizerOTMappingAdapter(norm="lpl1")),
         (ClassRegularizerOTMappingAdapter(norm="l1l2")),
         (LinearOTMappingAdapter()),
-        (CORALAdapter()),
+        (CORALAdapter(assume_centered=True)),
         (
             pytest.param(
                 MMDLSConSMappingAdapter(gamma=1e-3),
@@ -215,7 +216,7 @@ def test_new_X_adapt(estimator):
         OTMappingAdapter(),
         EntropicOTMappingAdapter(),
         LinearOTMappingAdapter(),
-        CORALAdapter(),
+        CORALAdapter(assume_centered=True),
         pytest.param(
             MMDLSConSMappingAdapter(gamma=1e-3),
             marks=pytest.mark.skipif(not torch, reason="PyTorch not installed"),


### PR DESCRIPTION
In https://arxiv.org/abs/1612.01939, the authors assume source and target data have a zero mean, i.e. $\mu_S=\mu_T=0$.
This PR adds an `assume_centered` argument to CORAL to center data during fitting and transforming data.