### PR TITLE
Fix: Dev scorer wasn't working with SourceOnly and TargetOnly

### DIFF
--- a/skada/deep/_baseline.py
+++ b/skada/deep/_baseline.py
@@ -63,7 +63,7 @@ def SourceOnly(module, layer_name=None, base_criterion=None, **kwargs):
     net = DomainAwareNet(
         module=DomainAwareModule,
         module__base_module=module,
-        module__layer_name=None,
+        module__layer_name=layer_name,
         iterator_train=DomainOnlyDataLoader,
         iterator_train__domain_used="source",
         criterion=DomainAwareCriterion,
@@ -100,7 +100,7 @@ def TargetOnly(module, layer_name=None, base_criterion=None, **kwargs):
     net = DomainAwareNet(
         module=DomainAwareModule,
         module__base_module=module,
-        module__layer_name=None,
+        module__layer_name=layer_name,
         iterator_train=DomainOnlyDataLoader,
         iterator_train__domain_used="target",
         criterion=DomainAwareCriterion,

--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -417,6 +417,9 @@ class DeepEmbeddedValidation(_BaseDomainAwareScorer):
 
         if not isinstance(estimator, BaseEstimator):
             # The estimator is a deep model
+            if estimator.module_.layer_name is None:
+                raise ValueError("The layer_name of the estimator is not set.")
+
             transformer = estimator.predict_features
             has_transform_method = True
         else:


### PR DESCRIPTION
### Issue:
The `SourceOnly` and `TargetOnly` methods were not functioning as expected.

### Cause:
The default behavior was overriding the layer names, setting them to `None`, which caused the issue.

### Solution:
- Removed the default `None` assignment for layer names in the `selectSource` and `selectTarget` methods.

### Next Steps:
- Add relevant test cases to ensure proper functionality.
