### PR TITLE
[MRG] fix `predict_proba` for deep method

### DIFF
--- a/skada/deep/base.py
+++ b/skada/deep/base.py
@@ -7,13 +7,14 @@
 
 from abc import abstractmethod
 from typing import Dict, Any, Union
+from functools import partial
 
 import torch
 from torch.utils.data import DataLoader, Sampler, Dataset
 from sklearn.base import _clone_parametrized
 from skorch import NeuralNetClassifier
 
-from .utils import _register_forwards_hook
+from .utils import _register_forwards_hook, _infer_predict_nonlinearity
 
 from skada.base import _DAMetadataRequesterMixin
 
@@ -621,6 +622,7 @@ class DomainAwareNet(NeuralNetClassifier, _DAMetadataRequesterMixin):
             The predicted class probabilities.
         """
         X, _ = self._prepare_input(X, sample_domain, sample_weight)
+        self.predict_nonlinearity = _infer_predict_nonlinearity(self)
         return super().predict_proba(X, **predict_params)
 
     def predict_features(self, X: Union[Dict, torch.Tensor, np.ndarray, Dataset]):

--- a/skada/deep/base.py
+++ b/skada/deep/base.py
@@ -603,7 +603,7 @@ class DomainAwareNet(NeuralNetClassifier, _DAMetadataRequesterMixin):
         """Return the nonlinearity to be applied to the prediction
 
         This can be useful, e.g., when
-        :func:`~skorch.classifier.NeuralNetClassifier.predict_proba`
+        :func:`~skada.DomainAwareNet.predict_proba`
         should return probabilities but a criterion is used that does
         not expect probabilities. In that case, the module can return
         whatever is required by the criterion and the
@@ -611,8 +611,8 @@ class DomainAwareNet(NeuralNetClassifier, _DAMetadataRequesterMixin):
         probabilities.
 
         The nonlinearity is applied only when calling
-        :func:`~skorch.classifier.NeuralNetClassifier.predict` or
-        :func:`~skorch.classifier.NeuralNetClassifier.predict_proba`
+        :func:`~skada.DomainAwareNet.predict` or
+        :func:`~skada.DomainAwareNet.predict_proba`
         but not anywhere else -- notably, the loss is unaffected by
         this nonlinearity.
 

--- a/skada/deep/utils.py
+++ b/skada/deep/utils.py
@@ -5,7 +5,7 @@
 import numbers
 from functools import partial
 
-from skorch.utils import _identity, _sigmoid_then_2d, _make_2d_probs
+from skorch.utils import _identity
 import torch
 from torch.nn import BCELoss, BCEWithLogitsLoss, CrossEntropyLoss
 
@@ -78,10 +78,17 @@ def _infer_predict_nonlinearity(net):
     if isinstance(criterion, CrossEntropyLoss):
         return partial(torch.softmax, dim=-1)
 
-    if isinstance(criterion, BCEWithLogitsLoss):
-        return _sigmoid_then_2d
+    # TODO: handle more cases
+    # - BCEWithLogitsLoss
+    # - BCELoss
+    # - MSELoss
+    # But first, see: https://github.com/scikit-adaptation/skada/issues/249
 
-    if isinstance(criterion, BCELoss):
-        return _make_2d_probs
+    # from skorch.utils import _sigmoid_then_2d, _make_2d_probs
+    # if isinstance(criterion, BCEWithLogitsLoss):
+    #     return _sigmoid_then_2d
+
+    # if isinstance(criterion, BCELoss):
+    #     return _make_2d_probs
 
     return _identity


### PR DESCRIPTION
The `predict_proba` of deep method was choosing the nonlin attributes by looking at `criterion` attribute of the solvers. The `DomainAwareNet` has a `DomainAwareCriterion` as criterion. We should choose the nonlin base on `criterion.base_criterion`. This PR does that.