### PR TITLE
[WIP] Add CAN Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,4 +237,4 @@ The library is distributed under the 3-Clause BSD license.
 
 [32] Hu, D., Liang, J., Liew, J. H., Xue, C., Bai, S., & Wang, X. (2023). [Mixed Samples as Probes for Unsupervised Model Selection in Domain Adaptation](https://proceedings.neurips.cc/paper_files/paper/2023/file/7721f1fea280e9ffae528dc78c732576-Paper-Conference.pdf). Advances in Neural Information Processing Systems 36 (2024).
 
-
+[33] Kang, G., Jiang, L., Yang, Y., & Hauptmann, A. G. (2019). [Contrastive Adaptation Network for Unsupervised Domain Adaptation](https://arxiv.org/abs/1901.00976). In Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (pp. 4893-4902).

--- a/docs/source/all.rst
+++ b/docs/source/all.rst
@@ -147,6 +147,7 @@ Deep learning DA :py:mod:`skada.deep`:
    DeepJDOTLoss
    DANLoss
    CDANLoss
+   CANLoss
 
 .. autosummary::
    :toctree: gen_modules/
@@ -155,10 +156,12 @@ Deep learning DA :py:mod:`skada.deep`:
    dan_loss
    deepcoral_loss
    deepjdot_loss
+   cdd_loss
    DeepCoral
    DeepJDOT
    DANN
    CDAN
+   CAN
 
 
 

--- a/skada/deep/__init__.py
+++ b/skada/deep/__init__.py
@@ -1,5 +1,6 @@
 # Author: Theo Gnassounou <theo.gnassounou@inria.fr>
 #         Remi Flamary <remi.flamary@polytechnique.edu>
+#         Yanis Lalou <yanis.lalou@polytechnique.edu>
 #
 # License: BSD 3-Clause
 
@@ -14,7 +15,7 @@ except (ImportError, ModuleNotFoundError) as e:
         "torch and skorch are required for importing skada.deep.* modules."
     ) from e
 
-from ._divergence import DeepCoral, DeepCoralLoss, DANLoss, DAN
+from ._divergence import DeepCoral, DeepCoralLoss, DANLoss, DAN, CAN, CANLoss
 from ._optimal_transport import DeepJDOT, DeepJDOTLoss
 from ._adversarial import DANN, CDAN, DANNLoss, CDANLoss
 from ._baseline import SourceOnly, TargetOnly
@@ -35,6 +36,8 @@ __all__ = [
     'DANN',
     'CDANLoss',
     'CDAN',
+    'CANLoss',
+    'CAN',
     'SourceOnly',
     'TargetOnly',
 ]

--- a/skada/deep/_divergence.py
+++ b/skada/deep/_divergence.py
@@ -1,5 +1,6 @@
 # Author: Theo Gnassounou <theo.gnassounou@inria.fr>
 #         Remi Flamary <remi.flamary@polytechnique.edu>
+#         Yanis Lalou <yanis.lalou@polytechnique.edu>
 #
 # License: BSD 3-Clause
 import torch
@@ -12,7 +13,7 @@ from skada.deep.base import (
     DomainBalancedDataLoader,
 )
 
-from .losses import dan_loss, deepcoral_loss
+from .losses import cdd_loss, dan_loss, deepcoral_loss
 
 
 class DeepCoralLoss(BaseDALoss):
@@ -177,6 +178,127 @@ def DAN(module, layer_name, reg=1, sigmas=None, base_criterion=None, **kwargs):
         criterion__base_criterion=base_criterion,
         criterion__reg=reg,
         criterion__adapt_criterion=DANLoss(sigmas=sigmas),
+        **kwargs,
+    )
+    return net
+
+
+class CANLoss(BaseDALoss):
+    """Loss for Contrastive Adaptation Network (CAN)
+
+    This loss implements the contrastive domain discrepancy (CDD)
+    as described in [X].
+
+    Parameters
+    ----------
+    distance_threshold : float, optional (default=0.5)
+        Distance threshold for discarding the samples that are
+        to far from the centroids.
+    class_threshold : int, optional (default=3)
+        Minimum number of samples in a class to be considered for the loss.
+    sigmas : array like, default=None,
+        If array, sigmas used for the multi gaussian kernel.
+        If None, uses sigmas proposed  in [1]_.
+
+    References
+    ----------
+    .. [X] Kang, G., Jiang, L., Yang, Y., & Hauptmann, A. G. (2019).
+           Contrastive adaptation network for unsupervised domain adaptation.
+           In Proceedings of the IEEE/CVF Conference on Computer Vision
+           and Pattern Recognition (pp. 4893-4902).
+    """
+
+    def __init__(
+        self,
+        distance_threshold=0.5,
+        class_threshold=3,
+        sigmas=None,
+    ):
+        super().__init__()
+        self.distance_threshold = distance_threshold
+        self.class_threshold = class_threshold
+        self.sigmas = sigmas
+
+    def forward(
+        self,
+        y_s,
+        y_pred_s,
+        y_pred_t,
+        domain_pred_s,
+        domain_pred_t,
+        features_s,
+        features_t,
+    ):
+        loss = cdd_loss(
+            y_s,
+            features_s,
+            features_t,
+            sigmas=self.sigmas,
+            distance_threshold=self.distance_threshold,
+            class_threshold=self.class_threshold,
+        )
+
+        return loss
+
+
+def CAN(
+    module,
+    layer_name,
+    reg=1,
+    distance_threshold=0.5,
+    class_threshold=3,
+    sigmas=None,
+    base_criterion=None,
+    **kwargs,
+):
+    """Contrastive Adaptation Network (CAN) domain adaptation method.
+
+    From [X].
+
+    Parameters
+    ----------
+    module : torch module (class or instance)
+        A PyTorch :class:`~torch.nn.Module`.
+    layer_name : str
+        The name of the module's layer whose outputs are
+        collected during the training for the adaptation.
+    reg : float, optional (default=1)
+        Regularization parameter for DA loss.
+    distance_threshold : float, optional (default=0.5)
+        Distance threshold for discarding the samples that are
+        to far from the centroids.
+    class_threshold : int, optional (default=3)
+        Minimum number of samples in a class to be considered for the loss.
+    sigmas : array like, default=None,
+        If array, sigmas used for the multi gaussian kernel.
+        If None, uses sigmas proposed  in [1]_.
+    base_criterion : torch criterion (class)
+        The base criterion used to compute the loss with source
+        labels. If None, the default is `torch.nn.CrossEntropyLoss`.
+
+    References
+    ----------
+    .. [X] Kang, G., Jiang, L., Yang, Y., & Hauptmann, A. G. (2019).
+           Contrastive adaptation network for unsupervised domain adaptation.
+           In Proceedings of the IEEE/CVF Conference on Computer Vision
+           and Pattern Recognition (pp. 4893-4902).
+    """
+    if base_criterion is None:
+        base_criterion = torch.nn.CrossEntropyLoss()
+
+    net = DomainAwareNet(
+        module=DomainAwareModule,
+        module__base_module=module,
+        module__layer_name=layer_name,
+        iterator_train=DomainBalancedDataLoader,
+        criterion=DomainAwareCriterion,
+        criterion__base_criterion=base_criterion,
+        criterion__reg=reg,
+        criterion__adapt_criterion=CANLoss(
+            distance_threshold=distance_threshold,
+            class_threshold=class_threshold,
+            sigmas=sigmas,
+        ),
         **kwargs,
     )
     return net

--- a/skada/deep/_divergence.py
+++ b/skada/deep/_divergence.py
@@ -187,7 +187,7 @@ class CANLoss(BaseDALoss):
     """Loss for Contrastive Adaptation Network (CAN)
 
     This loss implements the contrastive domain discrepancy (CDD)
-    as described in [X].
+    as described in [33].
 
     Parameters
     ----------
@@ -202,7 +202,7 @@ class CANLoss(BaseDALoss):
 
     References
     ----------
-    .. [X] Kang, G., Jiang, L., Yang, Y., & Hauptmann, A. G. (2019).
+    .. [33] Kang, G., Jiang, L., Yang, Y., & Hauptmann, A. G. (2019).
            Contrastive adaptation network for unsupervised domain adaptation.
            In Proceedings of the IEEE/CVF Conference on Computer Vision
            and Pattern Recognition (pp. 4893-4902).
@@ -253,7 +253,7 @@ def CAN(
 ):
     """Contrastive Adaptation Network (CAN) domain adaptation method.
 
-    From [X].
+    From [33].
 
     Parameters
     ----------
@@ -278,7 +278,7 @@ def CAN(
 
     References
     ----------
-    .. [X] Kang, G., Jiang, L., Yang, Y., & Hauptmann, A. G. (2019).
+    .. [33] Kang, G., Jiang, L., Yang, Y., & Hauptmann, A. G. (2019).
            Contrastive adaptation network for unsupervised domain adaptation.
            In Proceedings of the IEEE/CVF Conference on Computer Vision
            and Pattern Recognition (pp. 4893-4902).

--- a/skada/deep/_divergence.py
+++ b/skada/deep/_divergence.py
@@ -200,6 +200,8 @@ class CANLoss(BaseDALoss):
     sigmas : array like, default=None,
         If array, sigmas used for the multi gaussian kernel.
         If None, uses sigmas proposed  in [1]_.
+    target_kmeans : sklearn KMeans instance, default=None,
+        Pre-computed target KMeans clustering model.
 
     References
     ----------
@@ -214,13 +216,13 @@ class CANLoss(BaseDALoss):
         distance_threshold=0.5,
         class_threshold=3,
         sigmas=None,
-        source_centroids=None,
+        target_kmeans=None,
     ):
         super().__init__()
         self.distance_threshold = distance_threshold
         self.class_threshold = class_threshold
         self.sigmas = sigmas
-        self.source_centroids = source_centroids
+        self.target_kmeans = target_kmeans
 
     def forward(
         self,
@@ -237,7 +239,7 @@ class CANLoss(BaseDALoss):
             features_s,
             features_t,
             sigmas=self.sigmas,
-            source_centroids=self.source_centroids,
+            target_kmeans=self.target_kmeans,
             distance_threshold=self.distance_threshold,
             class_threshold=self.class_threshold,
         )

--- a/skada/deep/_divergence.py
+++ b/skada/deep/_divergence.py
@@ -13,6 +13,7 @@ from skada.deep.base import (
     DomainBalancedDataLoader,
 )
 
+from .callbacks import ComputeSourceCentroids
 from .losses import cdd_loss, dan_loss, deepcoral_loss
 
 
@@ -213,11 +214,13 @@ class CANLoss(BaseDALoss):
         distance_threshold=0.5,
         class_threshold=3,
         sigmas=None,
+        source_centroids=None,
     ):
         super().__init__()
         self.distance_threshold = distance_threshold
         self.class_threshold = class_threshold
         self.sigmas = sigmas
+        self.source_centroids = source_centroids
 
     def forward(
         self,
@@ -234,6 +237,7 @@ class CANLoss(BaseDALoss):
             features_s,
             features_t,
             sigmas=self.sigmas,
+            source_centroids=self.source_centroids,
             distance_threshold=self.distance_threshold,
             class_threshold=self.class_threshold,
         )
@@ -299,6 +303,7 @@ def CAN(
             class_threshold=class_threshold,
             sigmas=sigmas,
         ),
+        callbacks=[ComputeSourceCentroids()],
         **kwargs,
     )
     return net

--- a/skada/deep/callbacks.py
+++ b/skada/deep/callbacks.py
@@ -1,0 +1,55 @@
+# Author: Yanis Lalou <yanis.lalou@polytechnique.edu>
+#
+# License: BSD 3-Clause
+
+import torch
+import torch.nn.functional as F
+from skorch.callbacks import Callback
+
+
+class ComputeSourceCentroids(Callback):
+    """Callback to compute centroids of source domain features for each class.
+
+    This callback computes the centroids of the normalized features for each class
+    in the source domain at the beginning of each epoch. The centroids are stored
+    in the adaptation criterion of the network for later use.
+    """
+
+    def on_epoch_begin(self, net, dataset_train=None, **kwargs):
+        """Compute source centroids at the beginning of each epoch.
+
+        Parameters
+        ----------
+        net : NeuralNet
+            The neural network being trained.
+        dataset_train : Dataset, optional
+            The training dataset.
+        **kwargs : dict
+            Additional arguments passed to the callback.
+        """
+        X, y = dataset_train.X, dataset_train.y
+
+        X, y_ = net._prepare_input(X)
+        y = y_ if y is None else y
+
+        # Keep only source samples
+        X_s = X["X"][X["sample_domain"] >= 0]
+        y_s = y[X["sample_domain"] >= 0]
+
+        features_s = net.predict_features(X_s)
+
+        features_s = torch.tensor(features_s, device=net.device)
+        y_s = torch.tensor(y_s, device=net.device)
+
+        n_classes = len(y_s.unique())
+        source_centroids = []
+
+        for c in range(n_classes):
+            mask = y_s == c
+            if mask.sum() > 0:
+                class_features = features_s[mask]
+                normalized_features = F.normalize(class_features, p=2, dim=1)
+                centroid = normalized_features.mean(dim=0)
+                source_centroids.append(centroid)
+
+        net.criterion__adapt_criterion.source_centroids = torch.stack(source_centroids)

--- a/skada/deep/losses.py
+++ b/skada/deep/losses.py
@@ -199,7 +199,7 @@ def cdd_loss(
     distance_threshold=0.5,
     class_threshold=3,
 ):
-    """Define the contrastive domain discrepancy loss based on [X]_.
+    """Define the contrastive domain discrepancy loss based on [33]_.
 
     Parameters
     ----------
@@ -225,8 +225,10 @@ def cdd_loss(
 
     References
     ----------
-    .. [X]  Y. Cao, Y. Yang, C. Tu, W. Wang, and D. Tao.
-            Contrastive Domain Adaptation. In NeurIPS, 2022.
+    .. [33] Kang, G., Jiang, L., Yang, Y., & Hauptmann, A. G. (2019).
+           Contrastive adaptation network for unsupervised domain adaptation.
+           In Proceedings of the IEEE/CVF Conference on Computer Vision
+           and Pattern Recognition (pp. 4893-4902).
     """
     n_classes = len(y_s.unique())
 

--- a/skada/deep/losses.py
+++ b/skada/deep/losses.py
@@ -250,7 +250,7 @@ def cdd_loss(
             if mask.sum() > 0:
                 class_features = features_s[mask]
                 normalized_features = F.normalize(class_features, p=2, dim=1)
-                centroid = normalized_features.mean(dim=0)
+                centroid = normalized_features.sum(dim=0)
                 source_centroids.append(centroid)
 
         # Use source centroids to initialize target clustering

--- a/skada/deep/tests/test_deep_divergence.py
+++ b/skada/deep/tests/test_deep_divergence.py
@@ -128,7 +128,7 @@ def test_can(sigmas, distance_threshold, class_threshold):
 
     method = CAN(
         ToyModule2D(),
-        reg=1,
+        reg=0.01,
         sigmas=sigmas,
         distance_threshold=distance_threshold,
         class_threshold=class_threshold,
@@ -148,5 +148,4 @@ def test_can(sigmas, distance_threshold, class_threshold):
     assert y_pred.shape[0] == X_test.shape[0]
 
     history = method.history_
-
     assert history[0]["train_loss"] > history[-1]["train_loss"]

--- a/skada/deep/tests/test_deep_divergence.py
+++ b/skada/deep/tests/test_deep_divergence.py
@@ -134,7 +134,7 @@ def test_can(sigmas, distance_threshold, class_threshold):
         class_threshold=class_threshold,
         layer_name="dropout",
         batch_size=10,
-        max_epochs=5,
+        max_epochs=10,
         train_split=None,
     )
 

--- a/skada/deep/tests/test_deep_divergence.py
+++ b/skada/deep/tests/test_deep_divergence.py
@@ -10,7 +10,7 @@ pytest.importorskip("torch")
 import numpy as np
 
 from skada.datasets import make_shifted_datasets
-from skada.deep import DAN, DeepCoral
+from skada.deep import CAN, DAN, DeepCoral
 from skada.deep.modules import ToyModule2D
 
 
@@ -87,6 +87,54 @@ def test_dan(sigmas):
         layer_name="dropout",
         batch_size=10,
         max_epochs=10,
+        train_split=None,
+    )
+
+    X, y, sample_domain = dataset.pack_train(as_sources=["s"], as_targets=["t"])
+    method.fit(X.astype(np.float32), y, sample_domain)
+
+    X_test, y_test, sample_domain_test = dataset.pack_test(as_targets=["t"])
+
+    y_pred = method.predict(X_test.astype(np.float32), sample_domain_test)
+
+    assert y_pred.shape[0] == X_test.shape[0]
+
+    history = method.history_
+
+    assert history[0]["train_loss"] > history[-1]["train_loss"]
+
+
+@pytest.mark.parametrize(
+    "sigmas, distance_threshold, class_threshold",
+    [
+        ([0.1, 0.2], 0.5, 3),
+        (None, 0.5, 3),
+        ([0.1, 0.2], 0.2, 5),
+    ],
+)
+def test_can(sigmas, distance_threshold, class_threshold):
+    module = ToyModule2D()
+    module.eval()
+
+    n_samples = 10
+    dataset = make_shifted_datasets(
+        n_samples_source=n_samples,
+        n_samples_target=n_samples,
+        shift="concept_drift",
+        noise=0.1,
+        random_state=42,
+        return_dataset=True,
+    )
+
+    method = CAN(
+        ToyModule2D(),
+        reg=1,
+        sigmas=sigmas,
+        distance_threshold=distance_threshold,
+        class_threshold=class_threshold,
+        layer_name="dropout",
+        batch_size=10,
+        max_epochs=5,
         train_split=None,
     )
 

--- a/skada/deep/utils.py
+++ b/skada/deep/utils.py
@@ -148,6 +148,9 @@ class SphericalKMeans:
         else:
             X = X.to(self.device)
 
+        # Normalize X
+        X = X / torch.norm(X, dim=1, keepdim=True)
+
         best_inertia = None
         best_centroids = None
         best_n_iter = None
@@ -168,7 +171,6 @@ class SphericalKMeans:
                 for k in range(self.n_clusters):
                     if torch.any(labels == k):
                         new_centroids[k] = X[labels == k].mean(dim=0)
-                new_centroids /= torch.norm(new_centroids, dim=1, keepdim=True)
 
                 # Check for convergence
                 if torch.allclose(centroids, new_centroids, atol=self.tol):
@@ -209,6 +211,9 @@ class SphericalKMeans:
             X = torch.tensor(X, dtype=torch.float32, device=self.device)
         else:
             X = X.to(self.device)
+
+        # No need to normalize X as it is going
+        # to be normalized in cosine_similarity
 
         dissimilarities = self._compute_dissimilarities(X, self.cluster_centers_)
         return torch.argmin(dissimilarities, dim=1)

--- a/skada/deep/utils.py
+++ b/skada/deep/utils.py
@@ -103,6 +103,11 @@ class SphericalKMeans:
 
     n_iter_ : int
         Number of iterations run.
+
+    References
+    ----------
+    Hornik, K., Feinerer, I., Kober, M., & Buchta, C. (2012). Spherical k-Means Clustering. 
+    Journal of Statistical Software, 50(10), 1–22. https://doi.org/10.18637/jss.v050.i10
     """
 
     def __init__(self, n_clusters=8, n_init=10, max_iter=300, tol=1e-4, 

--- a/skada/deep/utils.py
+++ b/skada/deep/utils.py
@@ -1,10 +1,12 @@
 # Author: Theo Gnassounou <theo.gnassounou@inria.fr>
 #         Remi Flamary <remi.flamary@polytechnique.edu>
+#         Yanis Lalou <yanis.lalou@polytechnique.edu>
 #
 # License: BSD 3-Clause
 import numbers
-
 import torch
+from torch.nn.functional import cosine_similarity
+from sklearn.utils.validation import check_is_fitted
 
 
 def _get_intermediate_layers(intermediate_layers, layer_name):
@@ -52,3 +54,165 @@ def check_generator(seed):
     raise ValueError(
         "%r cannot be used to seed a torch.Generator instance" % seed
     )
+
+
+class SphericalKMeans:
+    """Spherical K-Means clustering using PyTorch.
+
+    This algorithm is similar to K-Means but uses cosine similarity
+    instead of Euclidean distance.
+
+    Parameters
+    ----------
+    n_clusters : int, default=8
+        The number of clusters to form as well as the number of
+        centroids to generate.
+
+    n_init : int, default=10
+        Number of times the k-means algorithm will be run with different
+        centroid seeds.
+
+    max_iter : int, default=300
+        Maximum number of iterations of the spherical k-means algorithm
+        for a single run.
+
+    tol : float, default=1e-4
+        Relative tolerance with regards to Frobenius norm of the difference
+        in the cluster centers of two consecutive iterations to declare
+        convergence.
+
+    centroids : torch.Tensor or None, default=None
+        Initial centroids to use. If None, centroids are initialized randomly.
+
+    random_state : int or None, default=None
+        Determines random number generation for centroid initialization.
+
+    device : str or torch.device, default='cpu'
+        The device to use for computations.
+
+    Attributes
+    ----------
+    cluster_centers_ : torch.Tensor of shape (n_clusters, n_features)
+        Coordinates of cluster centers.
+
+    labels_ : torch.Tensor of shape (n_samples,)
+        Labels of each point.
+
+    inertia_ : float
+        Sum of squared distances of samples to their closest cluster center.
+
+    n_iter_ : int
+        Number of iterations run.
+    """
+
+    def __init__(self, n_clusters=8, n_init=10, max_iter=300, tol=1e-4, 
+                 centroids=None, random_state=None, device='cpu'):
+        self.n_clusters = n_clusters
+        self.n_init = n_init
+        self.max_iter = max_iter
+        self.tol = tol
+        self.centroids = centroids
+        self.random_state = random_state
+        self.device = device
+
+    def _init_centroids(self, X):
+        # Randomly initialize centroids
+        n_samples = X.shape[0]
+        indices = torch.randperm(n_samples, device=self.device)[:self.n_clusters]
+        centroids = X[indices]
+        return centroids / torch.norm(centroids, dim=1, keepdim=True)
+
+    def fit(self, X, y=None):
+        """Compute spherical k-means clustering.
+
+        Parameters
+        ----------
+        X : torch.Tensor of shape (n_samples, n_features)
+            Training instances to cluster.
+
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
+        Returns
+        -------
+        self : object
+            Fitted estimator.
+        """
+        if not isinstance(X, torch.Tensor):
+            X = torch.tensor(X, dtype=torch.float32, device=self.device)
+        else:
+            X = X.to(self.device)
+
+        best_inertia = None
+        best_centroids = None
+        best_n_iter = None
+
+        for _ in range(self.n_init):
+            if self.centroids is None:
+                centroids = self._init_centroids(X)
+            else:
+                centroids = self.centroids.to(self.device)
+
+            for n_iter in range(self.max_iter):
+                # Assign samples to closest centroids
+                similarities = self._compute_similarities(X, centroids)
+                distances = 0.5 * (1 - similarities)
+                labels = torch.argmin(distances, dim=1)
+
+                # Update centroids
+                new_centroids = torch.zeros_like(centroids)
+                for k in range(self.n_clusters):
+                    if torch.any(labels == k):
+                        new_centroids[k] = X[labels == k].mean(dim=0)
+                new_centroids /= torch.norm(new_centroids, dim=1, keepdim=True)
+
+                # Check for convergence
+                if torch.allclose(centroids, new_centroids, atol=self.tol):
+                    break
+
+                centroids = new_centroids
+
+            # Compute inertia
+            inertia = 0.5 * (1 - self._compute_similarities(X, centroids[labels])).sum().item()
+
+            if best_inertia is None or inertia < best_inertia:
+                best_inertia = inertia
+                best_centroids = centroids
+                best_n_iter = n_iter
+
+        self.cluster_centers_ = best_centroids
+        self.inertia_ = best_inertia
+        self.n_iter_ = best_n_iter + 1
+
+        return self
+
+    def predict(self, X):
+        """Predict the closest cluster each sample in X belongs to.
+
+        Parameters
+        ----------
+        X : torch.Tensor of shape (n_samples, n_features)
+            New data to predict.
+
+        Returns
+        -------
+        labels : torch.Tensor of shape (n_samples,)
+            Index of the cluster each sample belongs to.
+        """
+        check_is_fitted(self)
+        if not isinstance(X, torch.Tensor):
+            X = torch.tensor(X, dtype=torch.float32, device=self.device)
+        else:
+            X = X.to(self.device)
+
+        similarities = self._compute_similarities(X, self.cluster_centers_)
+        distances = 0.5 * (1 - similarities)
+        return torch.argmin(distances, dim=1)
+
+    def _compute_similarities(self, X, centroids):
+        # Normalize input vectors
+        X_normalized = X / torch.norm(X, dim=1, keepdim=True)
+        centroids_normalized = centroids / torch.norm(centroids, dim=1, keepdim=True)
+        
+        # Compute cosine similarity
+        return torch.mm(X_normalized, centroids_normalized.t())

--- a/skada/deep/utils.py
+++ b/skada/deep/utils.py
@@ -170,7 +170,7 @@ class SphericalKMeans:
                 new_centroids = torch.zeros_like(centroids)
                 for k in range(self.n_clusters):
                     if torch.any(labels == k):
-                        new_centroids[k] = X[labels == k].mean(dim=0)
+                        new_centroids[k] = X[labels == k].sum(dim=0)
 
                 # Check for convergence
                 if torch.allclose(centroids, new_centroids, atol=self.tol):

--- a/skada/deep/utils.py
+++ b/skada/deep/utils.py
@@ -214,10 +214,5 @@ class SphericalKMeans:
         return torch.argmin(dissimilarities, dim=1)
 
     def _compute_dissimilarities(self, X, centroids):
-        # Normalize input vectors
-        X_normalized = X / torch.norm(X, dim=1, keepdim=True)
-        centroids_normalized = centroids / torch.norm(centroids, dim=1, keepdim=True)
-        
-        # Compute cosine similarity
-        similarities = torch.mm(X_normalized, centroids_normalized.t())
+        similarities = cosine_similarity(X.unsqueeze(1), centroids.unsqueeze(0), dim=2)
         return 0.5 * (1 - similarities)


### PR DESCRIPTION
Paper: https://arxiv.org/pdf/1901.00976
Mostly eq 3-4-5 + paragraph 3.4

### New Features:
* **CAN and CANLoss Implementation:**
  * Added `CANLoss` class to `skada/deep/_divergence.py` to implement the contrastive domain discrepancy (CDD) loss. 
  * Added `CAN` function to `skada/deep/_divergence.py` to implement the CAN domain adaptation method. 

### New Utilities:
* **SphericalKMeans:**
  * Added `SphericalKMeans` class to `skada/deep/utils.py` for clustering using cosine similarity.

### Testing:
* **New Tests for CAN:**
  * Added tests for CAN in `test_deep_divergence.py` to ensure the new method works as expected.

### Still needs to be done:
* Double check the implementation