### PR TITLE
[TO_REVIEW] Bug fix when None in make_da_pipeline

### DIFF
--- a/skada/_pipeline.py
+++ b/skada/_pipeline.py
@@ -108,7 +108,7 @@ def _wrap_with_selector(
     estimator: BaseEstimator,
     selector: Union[str, Callable[[BaseEstimator], BaseSelector]],
 ) -> BaseSelector:
-    if not isinstance(estimator, BaseSelector):
+    if (estimator is not None) and not isinstance(estimator, BaseSelector):
         if callable(selector):
             estimator = selector(estimator)
             if not isinstance(estimator, BaseSelector):

--- a/skada/tests/test_pipeline.py
+++ b/skada/tests/test_pipeline.py
@@ -33,6 +33,7 @@ def test_pipeline(da_dataset):
     # by default, each estimator in the pipeline is wrapped into `Shared` selector
     pipe = make_da_pipeline(
         StandardScaler(),
+        None,
         PCA(),
         SubspaceAlignmentAdapter(n_components=2),
         LogisticRegression(),


### PR DESCRIPTION
**Enhancement: Add compatibility with `None` in `skada` pipelines**

This PR introduces support for using `None` within `skada` pipelines, similar to how `scikit-learn` handles it. For example:

```Python
pipe = make_pipeline(
        StandardScaler(),
        None,  # Skip step
        PCA(),
        LogisticRegression(),
)
```

Now, `skada` pipelines can also include `None` as a step:

```Python
pipe = make_da_pipeline(
        StandardScaler(),
        None,  # Skip step
        PCA(),
        SubspaceAlignmentAdapter(n_components=2),
        LogisticRegression(),
)
```