### PR TITLE
[TO_REVIEW] Handle edge case Mixvalscorer

### DIFF
--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -773,23 +773,29 @@ class MixValScorer(_BaseDomainAwareScorer):
         # Calculate ICE scores based on ice_type
         # TODO: handle multiple target domains
         if self.ice_type in ["both", "intra"]:
-            ice_same = scorer(
-                estimator,
-                mix_inputs[same_idx],
-                mix_labels[same_idx],
-                sample_domain=np.full(same_idx.shape[0], -1),
-            )
+            if len(same_idx) == 0:
+                ice_same = np.nan
+            else:
+                ice_same = scorer(
+                    estimator,
+                    mix_inputs[same_idx],
+                    mix_labels[same_idx],
+                    sample_domain=np.full(same_idx.shape[0], -1),
+                )
 
         if self.ice_type in ["both", "inter"]:
-            ice_diff = scorer(
-                estimator,
-                mix_inputs[diff_idx],
-                mix_labels[diff_idx],
-                sample_domain=np.full(diff_idx.shape[0], -1),
-            )
+            if len(diff_idx) == 0:
+                ice_diff = np.nan
+            else:
+                ice_diff = scorer(
+                    estimator,
+                    mix_inputs[diff_idx],
+                    mix_labels[diff_idx],
+                    sample_domain=np.full(diff_idx.shape[0], -1),
+                )
 
         if self.ice_type == "both":
-            ice_score = (ice_same + ice_diff) / 2
+            ice_score = np.nanmean([ice_same, ice_diff])
         elif self.ice_type == "intra":
             ice_score = ice_same
         else:  # self.ice_type == 'inter'


### PR DESCRIPTION
This pull request includes changes to handle cases where there are no indices for intra-cluster or inter-cluster evaluations in the `MixValScorer`, and updates the corresponding tests to ensure these cases are properly handled.

### Handling NaN values in scoring:

* [`skada/metrics.py`](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bR776-R778): Added checks to set `ice_same` and `ice_diff` to `np.nan` if their respective index lists are empty. Modified the calculation of `ice_score` to use `np.nanmean` instead of a simple average. [[1]](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bR776-R778) [[2]](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bR787-R789) [[3]](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bL792-R798)

### Updating tests:

* [`skada/tests/test_scorer.py`](diffhunk://#diff-9a315372bb0e86a1789a29ff433b01df44f9eb2394ed330bbbab0c2bb8cc8571R301-R342): Added a `DummyEstimator` class and new test cases to verify that `ice_same` and `ice_diff` are set to `NaN` when appropriate, and that the combined score is calculated correctly even when individual scores are `NaN`.