### PR TITLE
[TO_REVIEW] Enhancements to DomainAwareNet and Scorers to handle `allow_source` arg

### DIFF
--- a/skada/deep/tests/test_deep_base.py
+++ b/skada/deep/tests/test_deep_base.py
@@ -119,7 +119,7 @@ def test_domainawaretraining():
     method.fit(X, y, sample_domain=sample_domain)
 
     y_pred = method.predict(X_test, sample_domain_test)
-    _ = method.predict_proba(X, sample_domain)
+    _ = method.predict_proba(X, sample_domain, allow_source=True)
     method.score(X_test, y_test, sample_domain_test)
 
     assert y_pred.shape[0] == X_test.shape[0]
@@ -134,7 +134,7 @@ def test_domainawaretraining():
     X_dict_test = {"X": X_test, "sample_domain": sample_domain_test}
 
     y_pred = method.predict(X_dict_test)
-    _ = method.predict_proba(X_dict)
+    _ = method.predict_proba(X_dict, allow_source=True)
     method.score(X_dict_test, y_test)
 
     assert y_pred.shape[0] == X_test.shape[0]
@@ -142,7 +142,7 @@ def test_domainawaretraining():
     # numpy input
     method.fit(X, y, sample_domain)
     y_pred = method.predict(X_test, sample_domain_test)
-    _ = method.predict_proba(X, sample_domain)
+    _ = method.predict_proba(X, sample_domain, allow_source=True)
     method.score(X_test, y_test, sample_domain_test)
 
     assert y_pred.shape[0] == X_test.shape[0]
@@ -150,7 +150,9 @@ def test_domainawaretraining():
     # tensor input
     method.fit(torch.tensor(X), torch.tensor(y), torch.tensor(sample_domain))
     y_pred = method.predict(torch.tensor(X_test), torch.tensor(sample_domain_test))
-    _ = method.predict_proba(torch.tensor(X), torch.tensor(sample_domain))
+    _ = method.predict_proba(
+        torch.tensor(X), torch.tensor(sample_domain), allow_source=True
+    )
     method.score(
         torch.tensor(X_test), torch.tensor(y_test), torch.tensor(sample_domain_test)
     )

--- a/skada/deep/tests/test_deep_baseline.py
+++ b/skada/deep/tests/test_deep_baseline.py
@@ -42,7 +42,7 @@ def test_sourceonly():
 
     # Fit and predict
     method.fit(X.astype(np.float32), y, sample_domain)
-    y_pred = method.predict(X.astype(np.float32), sample_domain)
+    y_pred = method.predict(X.astype(np.float32), sample_domain, allow_source=True)
 
     assert y_pred.shape[0] == X.shape[0]
 
@@ -53,7 +53,9 @@ def test_sourceonly():
     # Check accuracy is better on source domain than on target domain
     X_source, y_source, sample_domain_source = dataset.pack(as_sources=["s"])
     X_target, y_target, sample_domain_target = dataset.pack(as_targets=["t"])
-    y_pred_source = method.predict(X_source.astype(np.float32), sample_domain_source)
+    y_pred_source = method.predict(
+        X_source.astype(np.float32), sample_domain_source, allow_source=True
+    )
     y_pred_target = method.predict(X_target.astype(np.float32), sample_domain_target)
 
     acc_source = accuracy_score(y_source, y_pred_source)
@@ -89,7 +91,7 @@ def test_targetonly():
 
     # Fit and predict
     method.fit(X.astype(np.float32), y, sample_domain)
-    y_pred = method.predict(X.astype(np.float32), sample_domain)
+    y_pred = method.predict(X.astype(np.float32), sample_domain, allow_source=True)
 
     assert y_pred.shape[0] == X.shape[0]
 
@@ -100,7 +102,9 @@ def test_targetonly():
     # Check accuracy is better on target domain than on source domain
     X_source, y_source, sample_domain_source = dataset.pack(as_sources=["s"])
     X_target, y_target, sample_domain_target = dataset.pack(as_targets=["t"])
-    y_pred_source = method.predict(X_source.astype(np.float32), sample_domain_source)
+    y_pred_source = method.predict(
+        X_source.astype(np.float32), sample_domain_source, allow_source=True
+    )
     y_pred_target = method.predict(X_target.astype(np.float32), sample_domain_target)
 
     acc_source = accuracy_score(y_source, y_pred_source)

--- a/skada/deep/tests/test_deep_scorer.py
+++ b/skada/deep/tests/test_deep_scorer.py
@@ -52,8 +52,8 @@ def test_generic_scorer_on_deepmodel(scorer, da_dataset):
     # without dict
     estimator.fit(X, y, sample_domain=sample_domain)
 
-    estimator.predict(X_test, sample_domain=sample_domain_test)
-    estimator.predict_proba(X, sample_domain=sample_domain)
+    estimator.predict(X_test, sample_domain=sample_domain_test, allow_source=True)
+    estimator.predict_proba(X, sample_domain=sample_domain, allow_source=True)
 
     scores = scorer(estimator, X, y, sample_domain)
 
@@ -65,7 +65,7 @@ def test_generic_scorer_on_deepmodel(scorer, da_dataset):
     [
         PredictionEntropyScorer(),
         SoftNeighborhoodDensity(),
-        # DeepEmbeddedValidation(),
+        DeepEmbeddedValidation(),
     ],
 )
 def test_generic_scorer(scorer, da_dataset):

--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -188,11 +188,13 @@ class ImportanceWeightedScorer(_BaseDomainAwareScorer):
         else:
             warnings.warn("All weights are zero. Using uniform weights.")
             weights = np.ones_like(weights) / len(weights)
+
+        source_idx = extract_source_indices(sample_domain)
         score = scorer(
             estimator,
             X_source,
             y_source,
-            sample_domain=sample_domain[sample_domain >= 0],
+            sample_domain=sample_domain[source_idx],
             sample_weight=weights,
             allow_source=True,
             **params,

--- a/skada/metrics.py
+++ b/skada/metrics.py
@@ -167,7 +167,9 @@ class ImportanceWeightedScorer(_BaseDomainAwareScorer):
                 f"The estimator {estimator!r} does not."
             )
 
-        X, y, sample_domain = check_X_y_domain(X, y, sample_domain, allow_nd=True)
+        X, y, sample_domain = check_X_y_domain(
+            X, y, sample_domain, allow_nd=True, allow_source=True
+        )
         X_source, X_target, y_source, _ = source_target_split(
             X, y, sample_domain=sample_domain
         )
@@ -186,38 +188,15 @@ class ImportanceWeightedScorer(_BaseDomainAwareScorer):
         else:
             warnings.warn("All weights are zero. Using uniform weights.")
             weights = np.ones_like(weights) / len(weights)
-
-        if isinstance(estimator, BaseEstimator):
-            score = scorer(
-                estimator,
-                X_source,
-                y_source,
-                sample_domain=sample_domain[sample_domain >= 0],
-                sample_weight=weights,
-                allow_source=True,
-                **params,
-            )
-        else:
-            try:
-                from skorch import NeuralNet
-
-                if isinstance(estimator, NeuralNet):
-                    # Deep estimators dont accept allow_source parameter
-                    score = scorer(
-                        estimator,
-                        X_source,
-                        y_source,
-                        sample_domain=sample_domain[sample_domain >= 0],
-                        sample_weight=weights,
-                        **params,
-                    )
-                else:
-                    raise ValueError("Estimator is not a NeuralNet instance")
-            except ImportError:
-                raise ValueError(
-                    "Importance Weighted Scorer does not support estimator"
-                    f"of type {type(estimator).__name__}"
-                )
+        score = scorer(
+            estimator,
+            X_source,
+            y_source,
+            sample_domain=sample_domain[sample_domain >= 0],
+            sample_weight=weights,
+            allow_source=True,
+            **params,
+        )
 
         return self._sign * score
 
@@ -439,7 +418,9 @@ class DeepEmbeddedValidation(_BaseDomainAwareScorer):
             # We use the input data as features
             transformer = identity
 
-        X, y, sample_domain = check_X_y_domain(X, y, sample_domain, allow_nd=True)
+        X, y, sample_domain = check_X_y_domain(
+            X, y, sample_domain, allow_nd=True, allow_source=True
+        )
         source_idx = extract_source_indices(sample_domain)
         rng = check_random_state(self.random_state)
         X_train, X_val, _, y_val, _, sample_domain_val = train_test_split(
@@ -468,13 +449,9 @@ class DeepEmbeddedValidation(_BaseDomainAwareScorer):
         N_train, N_target = len(features_train), len(features_target)
         domain_pred = self.domain_classifier_.predict_proba(features_val)
         weights = (N_train / N_target) * domain_pred[:, :1] / domain_pred[:, 1:]
-        if not isinstance(estimator, BaseEstimator):
-            # Deep estimators dont accept allow_source parameter
-            y_pred = estimator.predict_proba(X_val, sample_domain_val)
-        else:
-            y_pred = estimator.predict_proba(
-                X_val, sample_domain=sample_domain_val, allow_source=True
-            )
+        y_pred = estimator.predict_proba(
+            X_val, sample_domain=sample_domain_val, allow_source=True
+        )
 
         error = self._loss_func(y_val, y_pred)
         assert weights.shape[0] == error.shape[0]
@@ -566,7 +543,7 @@ class CircularValidation(_BaseDomainAwareScorer):
         self.source_scorer = source_scorer
         self._sign = 1 if greater_is_better else -1
 
-    def _score(self, estimator, X, y, sample_domain=None):
+    def _score(self, estimator, X, y, sample_domain=None, **params):
         """
         Compute the score based on a circular validation strategy.
 
@@ -618,7 +595,8 @@ class CircularValidation(_BaseDomainAwareScorer):
             # the target domain will predict the same label for all
             # the source domain samples
             score = self.source_scorer(
-                y[source_idx], np.ones_like(y[source_idx]) * y_pred_target[0]
+                y[source_idx],
+                np.ones_like(y[source_idx]) * y_pred_target[0],
             )
         else:
             y_type = _find_y_type(y[source_idx])
@@ -778,6 +756,7 @@ class MixValScorer(_BaseDomainAwareScorer):
                 mix_inputs[same_idx],
                 mix_labels[same_idx],
                 sample_domain=np.full(same_idx.shape[0], -1),
+                **params,
             )
 
         if self.ice_type in ["both", "inter"]:
@@ -786,6 +765,7 @@ class MixValScorer(_BaseDomainAwareScorer):
                 mix_inputs[diff_idx],
                 mix_labels[diff_idx],
                 sample_domain=np.full(diff_idx.shape[0], -1),
+                **params,
             )
 
         if self.ice_type == "both":


### PR DESCRIPTION
The most important changes include adding support for source domains in various methods and updating the scoring mechanism to accommodate these changes.

Enhancements to `DomainAwareNet`:

* Added `allow_source` parameter to `predict`, `predict_proba`, and `score` methods to support source domains. (`skada/deep/base.py`) [[1]](diffhunk://#diff-7f8e921886d16f3ba7b7d824a3ed03e64e0fa03c2f972325004a6a518cfff23eR575) [[2]](diffhunk://#diff-7f8e921886d16f3ba7b7d824a3ed03e64e0fa03c2f972325004a6a518cfff23eR620-R621) [[3]](diffhunk://#diff-7f8e921886d16f3ba7b7d824a3ed03e64e0fa03c2f972325004a6a518cfff23eR668)
* Modified `check_X_domain` usage in `predict_proba` and `score` methods to handle `allow_source`. (`skada/deep/base.py`) [[1]](diffhunk://#diff-7f8e921886d16f3ba7b7d824a3ed03e64e0fa03c2f972325004a6a518cfff23eR631-R632) [[2]](diffhunk://#diff-7f8e921886d16f3ba7b7d824a3ed03e64e0fa03c2f972325004a6a518cfff23eL683-R697)

Updates to testing and metrics:

* Updated tests to include `allow_source` parameter in predictions. (`skada/deep/tests/test_deep_scorer.py`)
* Removed commented-out scorer in tests. (`skada/deep/tests/test_deep_scorer.py`)
* Updated `_score` method in `metrics.py` to handle `allow_source` parameter and removed outdated code. (`skada/metrics.py`) [[1]](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bL170-R172) [[2]](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bL200-L220) [[3]](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bL471-L474)
* Added `allow_source` parameter to various scoring functions and ensured compatibility with deep estimators. (`skada/metrics.py`) [[1]](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bL442-R423) [[2]](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bL621-R599) [[3]](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bR759) [[4]](diffhunk://#diff-4384c62462d0266c1d4ec08aac2e33b735a06e87000ff0ab0f11a8523862cd3bR768)
