### PR TITLE
[TO_REVIEW] Handle edge cases for CAN

### DIFF
--- a/skada/deep/tests/test_deep_divergence.py
+++ b/skada/deep/tests/test_deep_divergence.py
@@ -9,9 +9,11 @@ from skorch.callbacks import EpochScoring
 pytest.importorskip("torch")
 
 import numpy as np
+import torch
 
 from skada.datasets import make_shifted_datasets
 from skada.deep import CAN, DAN, DeepCoral
+from skada.deep.losses import cdd_loss
 from skada.deep.modules import ToyModule2D
 
 
@@ -195,3 +197,14 @@ def test_can_with_custom_callbacks():
     callback_classes = [cb.__class__.__name__ for cb in method.callbacks]
     assert "EpochScoring" in callback_classes
     assert "ComputeSourceCentroids" in callback_classes
+
+
+def test_cdd_loss_edge_cases():
+    # Test when median pairwise distance is 0
+    features_s = torch.ones((4, 2))  # All features are identical
+    features_t = torch.randn((4, 2))
+    y_s = torch.tensor([0, 0, 1, 1])  # Two classes
+
+    # This should not raise any errors due to the eps we added
+    loss = cdd_loss(y_s, features_s, features_t)
+    assert not np.isnan(loss)


### PR DESCRIPTION
This pull request includes several updates to the `cdd_loss` function in `skada/deep/losses.py` and adds new test cases to ensure edge cases are handled correctly.

### Improvements to `cdd_loss` function:

* [`skada/deep/losses.py`](diffhunk://#diff-0774706cdd6571bdf61f65dbc2fe0fd5c9e6ae928b28459a523339e962180212R256-R257): Stacked `source_centroids` using `torch.stack` to ensure they are properly aggregated.
* [`skada/deep/losses.py`](diffhunk://#diff-0774706cdd6571bdf61f65dbc2fe0fd5c9e6ae928b28459a523339e962180212L282-R289): Added a small epsilon (`eps`) to the median pairwise distance calculation to avoid division by zero errors.
* [`skada/deep/losses.py`](diffhunk://#diff-0774706cdd6571bdf61f65dbc2fe0fd5c9e6ae928b28459a523339e962180212L298-R338): Added checks to ensure intra-class and inter-class domain discrepancy measures (`e1`, `e2`, `e3`) are set to zero if their corresponding masks sum to zero. This prevents potential errors from invalid operations.

### Enhancements to tests:

* [`skada/deep/tests/test_deep_divergence.py`](diffhunk://#diff-4a4c6ab899ff86f7bc4d7db095dfc066f1a8b843ac58284dbc9cb8d565b5584bR200-R210): Added a new test function `test_cdd_loss_edge_cases` to verify that `cdd_loss` handles edge cases correctly, such as when all source features are identical.