### PR TITLE
[TO_REVIEW] Add epsilon in MCC to prevent log(0)

### DIFF
--- a/skada/deep/_class_confusion.py
+++ b/skada/deep/_class_confusion.py
@@ -25,6 +25,8 @@ class MCCLoss(BaseDALoss):
     T : float, default=1
         Temperature parameter for the scaling.
         If T=1, the scaling is a softmax function.
+    eps : float, default=1e-7
+        Small constant added to median distance calculation for numerical stability.
 
     References
     ----------
@@ -33,9 +35,10 @@ class MCCLoss(BaseDALoss):
             In ECCV, 2020.
     """
 
-    def __init__(self, T=1):
+    def __init__(self, T=1, eps=1e-7):
         super().__init__()
         self.T = T
+        self.eps = eps
 
     def forward(
         self,
@@ -51,6 +54,7 @@ class MCCLoss(BaseDALoss):
         loss = mcc_loss(
             y_pred_t,
             T=self.T,
+            eps=self.eps,
         )
         return loss
 

--- a/skada/deep/losses.py
+++ b/skada/deep/losses.py
@@ -368,7 +368,7 @@ def probability_scaling(logits, temperature=1):
     return torch.nn.functional.softmax(logits / temperature, dim=1)
 
 
-def mcc_loss(y, T=1):
+def mcc_loss(y, T=1, eps=1e-7):
     """Estimate the Frobenius norm divide by 4*n**2
        for DeepCORAL method [33]_.
 
@@ -376,9 +376,10 @@ def mcc_loss(y, T=1):
     ----------
     y : tensor
         The output of target domain of the model.
-
     T : float, default=1
         The temperature for the scaling.
+    eps : float, default=1e-7
+        Small constant added to median distance calculation for numerical stability.
 
     Returns
     -------
@@ -395,7 +396,6 @@ def mcc_loss(y, T=1):
     y_scaled = probability_scaling(y, temperature=T)
 
     # Uncertainty Reweighting & class correlation matrix
-    eps = 1e-7  # To avoid log(0)
     H = -torch.sum(y_scaled * torch.log(y_scaled + eps), axis=1)
     W = (1 + torch.exp(-H)) / torch.mean(1 + torch.exp(-H))
     y_weighted = torch.matmul(torch.diag(W), y_scaled)

--- a/skada/deep/losses.py
+++ b/skada/deep/losses.py
@@ -395,7 +395,8 @@ def mcc_loss(y, T=1):
     y_scaled = probability_scaling(y, temperature=T)
 
     # Uncertainty Reweighting & class correlation matrix
-    H = -torch.sum(y_scaled * torch.log(y_scaled), axis=1)
+    eps = 1e-7  # To avoid log(0)
+    H = -torch.sum(y_scaled * torch.log(y_scaled + eps), axis=1)
     W = (1 + torch.exp(-H)) / torch.mean(1 + torch.exp(-H))
     y_weighted = torch.matmul(torch.diag(W), y_scaled)
     C = torch.einsum("ij,ik->jk", y_scaled, y_weighted)


### PR DESCRIPTION
This pull request includes changes to the `mcc_loss` function to handle zero probabilities correctly, updates to the corresponding tests, and necessary imports.

### Improvements to `mcc_loss` function:

* [`skada/deep/losses.py`](diffhunk://#diff-0774706cdd6571bdf61f65dbc2fe0fd5c9e6ae928b28459a523339e962180212L398-R399): Added a small epsilon value to avoid taking the logarithm of zero, which can lead to numerical issues. (`[skada/deep/losses.pyL398-R399](diffhunk://#diff-0774706cdd6571bdf61f65dbc2fe0fd5c9e6ae928b28459a523339e962180212L398-R399)`)

### Updates to tests:

* [`skada/deep/tests/test_deep_class_confusion.py`](diffhunk://#diff-71736bf2bcae56dd6073bdfd1c728374aa1b4f9d9a72594e27a02b269b14a169R59-R81): Added a new test `test_mcc_with_zeros` to ensure that the `mcc_loss` function handles zero probabilities correctly. (`[skada/deep/tests/test_deep_class_confusion.pyR59-R81](diffhunk://#diff-71736bf2bcae56dd6073bdfd1c728374aa1b4f9d9a72594e27a02b269b14a169R59-R81)`)