### PR TITLE
[TO_REVIEW] Convert pseudo labels to float in mddloss forward function

### DIFF
--- a/skada/deep/_adversarial.py
+++ b/skada/deep/_adversarial.py
@@ -418,8 +418,8 @@ class MDDLoss(BaseDALoss):
         """Compute the domain adaptation loss"""
         # TODO: handle binary classification
         # Multiclass classification
-        pseudo_label_s = torch.argmax(y_pred_s, axis=-1)
-        pseudo_label_t = torch.argmax(y_pred_t, axis=-1)
+        pseudo_label_s = torch.argmax(y_pred_s, axis=-1).float()
+        pseudo_label_t = torch.argmax(y_pred_t, axis=-1).float()
 
         disc_loss_src = self.disc_criterion_(disc_pred_s, pseudo_label_s)
         disc_loss_tgt = self.disc_criterion_(disc_pred_t, pseudo_label_t)


### PR DESCRIPTION
This fixes the issue that we have with the benchopt test:
```
File "/home/runner/miniconda3/envs/bench_test_env/lib/python3.10/site-packages/skada/deep/_adversarial.py", line 424, in forward
[1125](https://github.com/scikit-adaptation/skada-bench/actions/runs/11665654916/job/32478825918?pr=195#step:7:1126)
    disc_loss_src = self.disc_criterion_(disc_pred_s, pseudo_label_s)
[1126](https://github.com/scikit-adaptation/skada-bench/actions/runs/11665654916/job/32478825918?pr=195#step:7:1127)
  File "/home/runner/miniconda3/envs/bench_test_env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
[1127](https://github.com/scikit-adaptation/skada-bench/actions/runs/11665654916/job/32478825918?pr=195#step:7:1128)
    return self._call_impl(*args, **kwargs)
[1128](https://github.com/scikit-adaptation/skada-bench/actions/runs/11665654916/job/32478825918?pr=195#step:7:1129)
  File "/home/runner/miniconda3/envs/bench_test_env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
[1129](https://github.com/scikit-adaptation/skada-bench/actions/runs/11665654916/job/32478825918?pr=195#step:7:1130)
    return forward_call(*args, **kwargs)
[1130](https://github.com/scikit-adaptation/skada-bench/actions/runs/11665654916/job/32478825918?pr=195#step:7:1131)
  File "/home/runner/miniconda3/envs/bench_test_env/lib/python3.10/site-packages/torch/nn/modules/loss.py", line 1293, in forward
[1131](https://github.com/scikit-adaptation/skada-bench/actions/runs/11665654916/job/32478825918?pr=195#step:7:1132)
    return F.cross_entropy(
[1132](https://github.com/scikit-adaptation/skada-bench/actions/runs/11665654916/job/32478825918?pr=195#step:7:1133)
  File "/home/runner/miniconda3/envs/bench_test_env/lib/python3.10/site-packages/torch/nn/functional.py", line 3479, in cross_entropy
[1133](https://github.com/scikit-adaptation/skada-bench/actions/runs/11665654916/job/32478825918?pr=195#step:7:1134)
    return torch._C._nn.cross_entropy_loss(
[1134](https://github.com/scikit-adaptation/skada-bench/actions/runs/11665654916/job/32478825918?pr=195#step:7:1135)
RuntimeError: Expected floating point type for target with class probabilities, got Long
```

But for now, I don't see how to add a test in skada to reproduce this error