### PR TITLE
[TO_REVIEW] Remove redundant centroid computation in spherical k-means

### DIFF
--- a/skada/deep/_divergence.py
+++ b/skada/deep/_divergence.py
@@ -1,6 +1,7 @@
 # Author: Theo Gnassounou <theo.gnassounou@inria.fr>
 #         Remi Flamary <remi.flamary@polytechnique.edu>
 #         Yanis Lalou <yanis.lalou@polytechnique.edu>
+#         Antoine Collas <contact@antoinecollas.fr>
 #
 # License: BSD 3-Clause
 import torch

--- a/skada/deep/callbacks.py
+++ b/skada/deep/callbacks.py
@@ -67,7 +67,7 @@ class ComputeSourceCentroids(Callback):
             target_kmeans = SphericalKMeans(
                 n_clusters=n_classes,
                 random_state=0,
-                centroids=source_centroids,
+                initial_centroids=source_centroids,
                 device=features_t.device,
             )
             target_kmeans.fit(features_t)

--- a/skada/deep/losses.py
+++ b/skada/deep/losses.py
@@ -14,6 +14,7 @@ import torch.nn.functional as F
 from torch.nn.functional import mse_loss
 
 from skada.deep.base import BaseDALoss
+from skada.deep.utils import SphericalKMeans
 
 
 def deepcoral_loss(features, features_target, assume_centered=False):
@@ -198,7 +199,7 @@ def cdd_loss(
     y_s,
     features_s,
     features_t,
-    target_kmeans=None,
+    target_kmeans,
     sigmas=None,
     distance_threshold=0.5,
     class_threshold=3,
@@ -242,7 +243,7 @@ def cdd_loss(
     n_classes = len(y_s.unique())
 
     # Use pre-computed target_kmeans
-    if target_kmeans is None:
+    if type(target_kmeans) is not SphericalKMeans:
         raise ValueError(
             "cdd_loss: Please ensure `target_kmeans` is initialized before proceeding."
             "A fitted SphericalKMeans should be provided."

--- a/skada/deep/losses.py
+++ b/skada/deep/losses.py
@@ -5,7 +5,6 @@
 #
 # License: BSD 3-Clause
 
-import warnings
 from functools import partial
 
 import ot
@@ -15,7 +14,6 @@ import torch.nn.functional as F
 from torch.nn.functional import mse_loss
 
 from skada.deep.base import BaseDALoss
-from skada.deep.utils import SphericalKMeans
 
 
 def deepcoral_loss(features, features_target, assume_centered=False):
@@ -245,32 +243,10 @@ def cdd_loss(
 
     # Use pre-computed target_kmeans
     if target_kmeans is None:
-        with torch.no_grad():
-            warnings.warn(
-                "Source centroids are not computed for the whole training set, "
-                "computing them on the current batch set."
-            )
-
-            source_centroids = []
-
-            for c in range(n_classes):
-                mask = y_s == c
-                if mask.sum() > 0:
-                    class_features = features_s[mask]
-                    normalized_features = F.normalize(class_features, p=2, dim=1)
-                    centroid = normalized_features.sum(dim=0)
-                    source_centroids.append(centroid)
-
-            source_centroids = torch.stack(source_centroids)
-
-            # Use source centroids to initialize target clustering
-            target_kmeans = SphericalKMeans(
-                n_clusters=n_classes,
-                random_state=0,
-                centroids=source_centroids,
-                device=features_t.device,
-            )
-            target_kmeans.fit(features_t)
+        raise ValueError(
+            "cdd_loss: Please ensure `target_kmeans` is initialized before proceeding."
+            "A SphericalKMeans model should be fitted per epoch (and not per batch)."
+        )
 
     # Predict clusters for target samples
     cluster_labels_t = target_kmeans.predict(features_t)

--- a/skada/deep/losses.py
+++ b/skada/deep/losses.py
@@ -245,7 +245,7 @@ def cdd_loss(
     if target_kmeans is None:
         raise ValueError(
             "cdd_loss: Please ensure `target_kmeans` is initialized before proceeding."
-            "A SphericalKMeans model should be fitted per epoch (and not per batch)."
+            "A fitted SphericalKMeans should be provided."
         )
 
     # Predict clusters for target samples

--- a/skada/deep/tests/test_deep_divergence.py
+++ b/skada/deep/tests/test_deep_divergence.py
@@ -15,6 +15,7 @@ from skada.datasets import make_shifted_datasets
 from skada.deep import CAN, DAN, DeepCoral
 from skada.deep.losses import cdd_loss, dan_loss
 from skada.deep.modules import ToyModule2D
+from skada.deep.utils import SphericalKMeans
 
 
 @pytest.mark.parametrize(
@@ -205,8 +206,15 @@ def test_cdd_loss_edge_cases():
     features_t = torch.randn((4, 2))
     y_s = torch.tensor([0, 0, 1, 1])  # Two classes
 
+    # Fit a SphericalKMeans
+    target_kmeans = SphericalKMeans(
+        n_clusters=len(torch.unique(y_s)),
+        random_state=0,
+    )
+    target_kmeans.fit(features_t)
+
     # This should not raise any errors due to the eps we added
-    loss = cdd_loss(y_s, features_s, features_t)
+    loss = cdd_loss(y_s, features_s, features_t, target_kmeans)
     assert not np.isnan(loss)
 
 

--- a/skada/deep/utils.py
+++ b/skada/deep/utils.py
@@ -158,6 +158,10 @@ class SphericalKMeans:
         self.max_iter = max_iter
         self.tol = tol
         self.centroids = centroids
+        if centroids is None:
+            self.learn_centroids = True
+        else:
+            self.learn_centroids = False
         self.random_state = random_state
         self.device = device
 
@@ -198,7 +202,7 @@ class SphericalKMeans:
             best_centroids = None
             best_n_iter = None
 
-            if self.centroids is None:
+            if self.learn_centroids:
                 for _ in range(self.n_init):
                     centroids = self._init_centroids(X)
                     inertia, centroids, n_iter = self._run_single_kmean(X, centroids)

--- a/skada/deep/utils.py
+++ b/skada/deep/utils.py
@@ -206,7 +206,7 @@ class SphericalKMeans:
                         best_n_iter = n_iter
 
             else:
-                initial_centroids = self.initial_centroids.to(self.device)
+                initial_centroids = self.initial_centroids.to(self.device).clone()
                 inertia, centroids, n_iter = self._run_single_kmean(X, initial_centroids)
                 best_centroids = centroids
                 best_inertia = inertia
@@ -237,6 +237,7 @@ class SphericalKMeans:
         n_iter : int
             Number of iterations run.
         """
+        centroids = initial_centroids
         for n_iter in range(self.max_iter):
             # Assign samples to closest centroids
             dissimilarities = self._compute_dissimilarity_matrix(X, centroids)

--- a/skada/deep/utils.py
+++ b/skada/deep/utils.py
@@ -136,9 +136,6 @@ class SphericalKMeans:
     cluster_centers_ : torch.Tensor of shape (n_clusters, n_features)
         Coordinates of cluster centers.
 
-    labels_ : torch.Tensor of shape (n_samples,)
-        Labels of each point.
-
     inertia_ : float
         Sum of squared distances of samples to their closest cluster center.
 


### PR DESCRIPTION
This pull request includes changes to improve the spherical k-means clustering implementation.

Refactoring of clustering process:

* When using pre-initialised centroids, we do not run the k-means algorithm multiple times. Indeed in that case, the centroids will always have the same position.

Addition of helper method:

* Introduced `_run_single_kmean` method to encapsulate the logic for running a single spherical k-means clustering iteration, which includes computing dissimilarities, updating centroids, and checking for convergence. [[1]](diffhunk://#diff-7424c2462888e7d03099300b412067b00f00c28655a03e22dbc5b94b3d32686fL201-R241) [[2]](diffhunk://#diff-7424c2462888e7d03099300b412067b00f00c28655a03e22dbc5b94b3d32686fL227-R263)
