### PR TITLE
[MRG] do not try to complete when X_source is empty

### DIFF
--- a/skada/tests/test_utils.py
+++ b/skada/tests/test_utils.py
@@ -546,6 +546,17 @@ def test_source_target_merge():
         labels.shape[0] == y_source.shape[0] + y_target.shape[0]
     ), "labels shape mismatch"
 
+    # Test that no Error is raised for empty X_source and X_target in {-1, 0, 1}
+    X_target_discrete = np.array([[-1, -1], [0, 1], [1, -1]])
+    samples, _ = source_target_merge(np.array([]), X_target_discrete)
+    assert (
+        samples.shape[0] == X_target_discrete.shape[0]
+    ), "target_samples shape mismatch"
+    sample_domain_discrete = np.array([-1] * X_target_discrete.shape[0])
+    samples, _ = source_target_merge(
+        np.array([]), X_target_discrete, sample_domain=sample_domain_discrete
+    )
+
     # Test with empty samples
     with pytest.raises(
         ValueError, match="Only one array can be None or empty in each pair"

--- a/skada/utils.py
+++ b/skada/utils.py
@@ -517,9 +517,9 @@ def source_target_merge(
             pair_index = i+1 if index_is_empty == i else i
 
             # Infer the value of the empty array
-            # only if the dimension of the new array is not (0, ...)
-            dim_to_complete = (sample_domain.shape[0] - arrays[pair_index].shape[0],) + arrays[pair_index].shape[1:]
-            if dim_to_complete[0] > 0:
+            # only if the shape of the new array is not (0, ...)
+            shape_to_complete = (sample_domain.shape[0] - arrays[pair_index].shape[0],) + arrays[pair_index].shape[1:]
+            if shape_to_complete[0] > 0:
                 y_type = _find_y_type(arrays[pair_index])
                 if y_type == Y_Type.DISCRETE:
                     default_masked_label = _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL
@@ -528,7 +528,7 @@ def source_target_merge(
 
                 arrays[index_is_empty] = (
                     default_masked_label *
-                    np.ones(dim_to_complete)
+                    np.ones(shape_to_complete)
                 )
 
         # Check consistent number of samples in source-target arrays

--- a/skada/utils.py
+++ b/skada/utils.py
@@ -516,19 +516,18 @@ def source_target_merge(
 
             pair_index = i+1 if index_is_empty == i else i
 
-            y_type = _find_y_type(arrays[pair_index])
-            if y_type == Y_Type.DISCRETE:
-                default_masked_label = _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL
-            elif y_type == Y_Type.CONTINUOUS:
-                default_masked_label = _DEFAULT_MASKED_TARGET_REGRESSION_LABEL
+            len_to_complete = (sample_domain.shape[0] - arrays[pair_index].shape[0],) + arrays[pair_index].shape[1:]
+            if len_to_complete[0] > 0:
+                y_type = _find_y_type(arrays[pair_index])
+                if y_type == Y_Type.DISCRETE:
+                    default_masked_label = _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL
+                elif y_type == Y_Type.CONTINUOUS:
+                    default_masked_label = _DEFAULT_MASKED_TARGET_REGRESSION_LABEL
 
-            arrays[index_is_empty] = (
-                default_masked_label *
-                np.ones(
-                    (sample_domain.shape[0] - arrays[pair_index].shape[0],) +
-                    arrays[pair_index].shape[1:]
+                arrays[index_is_empty] = (
+                    default_masked_label *
+                    np.ones(len_to_complete)
                 )
-            )
 
         # Check consistent number of samples in source-target arrays
         # and the number inferred in the sample_domain

--- a/skada/utils.py
+++ b/skada/utils.py
@@ -516,8 +516,10 @@ def source_target_merge(
 
             pair_index = i+1 if index_is_empty == i else i
 
-            len_to_complete = (sample_domain.shape[0] - arrays[pair_index].shape[0],) + arrays[pair_index].shape[1:]
-            if len_to_complete[0] > 0:
+            # Infer the value of the empty array
+            # only if the dimension of the new array is not (0, ...)
+            dim_to_complete = (sample_domain.shape[0] - arrays[pair_index].shape[0],) + arrays[pair_index].shape[1:]
+            if dim_to_complete[0] > 0:
                 y_type = _find_y_type(arrays[pair_index])
                 if y_type == Y_Type.DISCRETE:
                     default_masked_label = _DEFAULT_MASKED_TARGET_CLASSIFICATION_LABEL
@@ -526,7 +528,7 @@ def source_target_merge(
 
                 arrays[index_is_empty] = (
                     default_masked_label *
-                    np.ones(len_to_complete)
+                    np.ones(dim_to_complete)
                 )
 
         # Check consistent number of samples in source-target arrays


### PR DESCRIPTION
When doing `source_target_merge(X_source, X_target)`, if one of the two `X_source` (or `X_target`) is empty then it infers what should be its default value based on the other one using the `_find_y_type` function.
This PR avoids this by checking the length of `sample_domain` for the empty `X_source` or `X_target`. If the length is 0, then it skips the imputation.